### PR TITLE
remove Datadog#configure call from library initializer

### DIFF
--- a/.reek
+++ b/.reek
@@ -88,6 +88,7 @@ UtilityFunction:
     - IronBank::Object#camelize_array
     - IronBank::Object#underscore_array
     - IronBank::OpenTracing#open_tracing_enabled?
+    - IronBank::OpenTracing#open_tracing_options
     - IronBank::QueryBuilder#range_query_builder
     - IronBank::Utils#lower_camelize
     - IronBank::Utils#upper_camelize

--- a/lib/iron_bank.rb
+++ b/lib/iron_bank.rb
@@ -144,12 +144,3 @@ IronBank::CatalogTier   = IronBank::Resources::ProductRatePlanChargeTier
 IronBank::Plan   = IronBank::Resources::RatePlan
 IronBank::Charge = IronBank::Resources::RatePlanCharge
 IronBank::Tier   = IronBank::Resources::RatePlanChargeTier
-
-Datadog.configure do |config|
-  config.tracer(
-    enabled: IronBank.configuration.open_tracing_enabled
-  )
-  # registers the tracing middleware.
-  config.use :faraday,
-             service_name: IronBank.configuration.open_tracing_service_name
-end

--- a/lib/iron_bank/open_tracing.rb
+++ b/lib/iron_bank/open_tracing.rb
@@ -10,7 +10,8 @@ module IronBank
     def open_tracing_options
       {
         distributed_tracing: true,
-        split_by_domain:     false
+        split_by_domain:     false,
+        service_name:        IronBank.configuration.open_tracing_service_name
       }
     end
   end

--- a/spec/iron_bank/open_tracing_spec.rb
+++ b/spec/iron_bank/open_tracing_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe IronBank::OpenTracing do
     let(:options) do
       {
         distributed_tracing: true,
-        split_by_domain:     false
+        split_by_domain:     false,
+        service_name:        'ironbank'
       }
     end
 


### PR DESCRIPTION
This changeset removes the `Datadog#configure` block from `lib/iron_bank.rb` and instead adds the `service_name` as an option for `ddtrace` middleware ([reference](https://github.com/DataDog/dd-trace-rb/blob/edd3d553177b1ee89517cbdcb30e8cb4a79d88af/lib/ddtrace/contrib/faraday/middleware.rb#L57)).