### PR TITLE
Add `IronBank::UnprocessableEntity` exception

### DIFF
--- a/lib/iron_bank/action.rb
+++ b/lib/iron_bank/action.rb
@@ -11,12 +11,15 @@ module IronBank
     end
 
     def call
-      IronBank.client.connection.post(endpoint, params).body
+      @body = IronBank.client.connection.post(endpoint, params).body
+      return body if success?
+
+      raise ::IronBank::UnprocessableEntity, errors
     end
 
     private
 
-    attr_reader :args
+    attr_reader :args, :body
 
     def initialize(args)
       @args = args
@@ -28,6 +31,22 @@ module IronBank
 
     def name
       self.class.name.split('::').last
+    end
+
+    def success?
+      response_object.fetch(:success, true)
+    end
+
+    def response_object
+      @response_object ||= begin
+        return {} unless body.is_a?(Array)
+
+        ::IronBank::Object.new(body.first).deep_underscore
+      end
+    end
+
+    def errors
+      { errors: response_object.fetch(:errors, []) }
     end
 
     def requests(type: :upper)

--- a/lib/iron_bank/error.rb
+++ b/lib/iron_bank/error.rb
@@ -12,6 +12,7 @@ module IronBank
         case status
         when 400      then IronBank::BadRequest
         when 404      then IronBank::NotFound
+        when 422      then IronBank::UnprocessableEntity
         when 429      then IronBank::TooManyRequests
         when 500      then IronBank::InternalServerError
         when 400..499 then IronBank::ClientError
@@ -33,6 +34,9 @@ module IronBank
 
   # Raised when Zuora returns a 404 HTTP status code
   class NotFound < ClientError; end
+
+  # Raised when Zuora return 422 and unsuccessful action responses
+  class UnprocessableEntity < Error; end
 
   # Raised when Zuora returns a 429 HTTP status code
   class TooManyRequests < ClientError; end

--- a/spec/iron_bank/action_spec.rb
+++ b/spec/iron_bank/action_spec.rb
@@ -5,16 +5,64 @@ require 'spec_helper'
 RSpec.describe IronBank::Action do
   let(:connection) { instance_double(Faraday::Connection) }
   let(:client)     { instance_double(IronBank::Client, connection: connection) }
+  let(:response)   { instance_double(Faraday::Response, body: body) }
+  let(:body)       { '' }
 
   before do
     allow(IronBank).to receive(:client).and_return(client)
+    allow(connection).to receive(:post).and_return(response)
   end
 
-  describe '::call' do
-    subject(:call) { described_class.call(anything) }
+  describe '.call' do
+    context 'without params' do
+      subject(:call) { described_class.call(anything) }
 
-    specify do
-      expect { call }.to raise_error(NameError)
+      specify do
+        expect { call }.to raise_error(NameError)
+      end
+    end
+
+    context 'with params on success' do
+      subject(:call) { SampleAction.call(anything) }
+
+      let(:body) do
+        [
+          {
+            'Success' => true,
+            'Id'      => 'account-id-123'
+          }
+        ]
+      end
+
+      it { expect(call).to eq(body) }
+    end
+
+    context 'with params on failure' do
+      subject(:call) { SampleAction.call(anything) }
+
+      let(:body) do
+        [
+          {
+            'Success' => false,
+            'Errors'  => [
+              {
+                'Code'    => 'MISSING_REQUIRED_VALUE',
+                'Message' => 'Missing required value: AccountId'
+              }
+            ]
+          }
+        ]
+      end
+
+      specify do
+        expect { call }.to raise_error(IronBank::UnprocessableEntity)
+      end
+    end
+  end
+
+  class SampleAction < IronBank::Action
+    def params
+      {}
     end
   end
 end


### PR DESCRIPTION
### Description

Add `IronBank::UnprocessableEntity` exception

It will raise the error when one of the following condition matches:
- When the response code is `422`
- When the action call returns `Success` body value as `false`

### Notes
Zuora doesn't return `422` in general, but it returns the `Success` body value as `false`

### Tasks
- [x] Add new error class
- [x] Raise the error when necessary

### Risks
**Low**
