### PR TITLE
Renew auth token on 401

### DIFF
--- a/.reek
+++ b/.reek
@@ -42,6 +42,10 @@ FeatureEnvy:
     - IronBank::Actions::Subscribe#hash_args
     - IronBank::Utils#camelize
 
+InstanceVariableAssumption:
+  exclude:
+    - IronBank::FaradayMiddleware::RetriableAuth
+
 IrresponsibleModule:
   exclude:
     - Sample

--- a/lib/iron_bank.rb
+++ b/lib/iron_bank.rb
@@ -57,7 +57,9 @@ require 'iron_bank/utils'
 require 'iron_bank/version'
 require 'iron_bank/csv'
 require 'iron_bank/error'
-require 'iron_bank/response/raise_error'
+require 'iron_bank/faraday_middleware/raise_error'
+require 'iron_bank/faraday_middleware/retriable_auth'
+require 'iron_bank/faraday_middleware'
 
 # Helpers
 require 'iron_bank/open_tracing'

--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -44,8 +44,10 @@ module IronBank
       @connection ||= Faraday.new(faraday_config) do |conn|
         conn.use      :ddtrace, open_tracing_options if open_tracing_enabled?
         conn.use      instrumenter, instrumenter_options if instrumenter
-        conn.use      IronBank::Response::RaiseError
+        conn.use      :raise_error
         conn.request  :json
+        conn.request  :retry, max: 2, retry_statuses: [401]
+        conn.request  :retriable_auth, auth
         conn.response :logger, IronBank.logger
         conn.response :json, content_type: /\bjson$/
         conn.adapter  Faraday.default_adapter

--- a/lib/iron_bank/faraday_middleware.rb
+++ b/lib/iron_bank/faraday_middleware.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# IronBank main module
+module IronBank
+  # IronBank Faraday middleware module
+  module FaradayMiddleware
+    if Faraday::Middleware.respond_to? :register_middleware
+      Faraday::Middleware.register_middleware \
+        raise_error: -> { RaiseError }
+
+      Faraday::Request.register_middleware \
+        retriable_auth: -> { RetriableAuth }
+    end
+  end
+end

--- a/lib/iron_bank/faraday_middleware/raise_error.rb
+++ b/lib/iron_bank/faraday_middleware/raise_error.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
+# IronBank main module
 module IronBank
-  # Faraday response middleware
-  module Response
+  # IronBank Faraday middleware module
+  module FaradayMiddleware
     # This class raises an exception based on the HTTP status code and the
     # `success` flag (if present in the response) from Zuora.
     class RaiseError < Faraday::Response::Middleware

--- a/lib/iron_bank/faraday_middleware/retriable_auth.rb
+++ b/lib/iron_bank/faraday_middleware/retriable_auth.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# IronBank main module
+module IronBank
+  # IronBank Faraday middleware module
+  module FaradayMiddleware
+    # This middleware reauthorize the request on unauthorized request
+    class RetriableAuth < Faraday::Middleware
+      def initialize(app, auth)
+        @auth = auth
+        super(app)
+      end
+
+      def call(env)
+        @env = env
+        renew_auth_header if env.status == 401
+
+        @app.call(env)
+      end
+
+      private
+
+      attr_reader :auth, :env
+
+      def renew_auth_header
+        auth.renew_session
+
+        # The :retry middleware use cached request's headers which doesn't retry
+        # the request headers automatically
+        env.request_headers = env.request_headers.merge(auth.header)
+      end
+    end
+  end
+end

--- a/spec/iron_bank/faraday_middleware/retriable_auth_spec.rb
+++ b/spec/iron_bank/faraday_middleware/retriable_auth_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe IronBank::FaradayMiddleware::RetriableAuth do
+  let(:session)         { instance_double(IronBank::Authentications::Token) }
+  let(:auth)            { instance_double(IronBank::Authentication) }
+  let(:new_auth_header) { { 'Authorization' => 'Bearer foo' } }
+
+  let(:make_request) { connection.get('/resource') }
+
+  let(:connection_stubs) do
+    Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get('/resource', new_auth_header) do
+        [200, { 'Content-Type' => 'application/json' }, '{"status": "ok"}']
+      end
+
+      stub.get('/resource') do
+        [401, { 'Content-Type' => 'application/json' }, '{"status": "bad"}']
+      end
+    end
+  end
+
+  before do
+    allow(auth).to receive(:renew_session).and_return(session).once
+    allow(auth).to receive(:header).and_return(new_auth_header).once
+  end
+
+  describe 'first request' do
+    before { make_request }
+
+    it { expect(auth).to have_received(:renew_session) }
+    it { expect(auth).to have_received(:header) }
+  end
+
+  describe 'second request' do
+    it 'includes the Authorization header with value' do
+      request_headers = make_request.env.request_headers
+      expect(request_headers['Authorization']).to eq('Bearer foo')
+    end
+
+    it 'returns ok' do
+      expect(make_request.body).to eq('{"status": "ok"}')
+    end
+  end
+
+  private
+
+  def connection
+    Faraday.new do |conn|
+      # To simulate a second request with new auth headers
+      conn.request :retry, max: 2, retry_statuses: [401]
+
+      conn.use     described_class, auth
+      conn.adapter :test, connection_stubs
+    end
+  end
+end


### PR DESCRIPTION
### Description

Renew auth token on 401

**When the response is 401:**
- Auto-renew auth token and update request header
- Retry the requests once more

**Additional changes:**
- Create retriable_auth middleware plug/unplug easily
- Move Faraday middlewares into its own folder
- Register middlewares

### Tasks
- [x] Renew auth token on 401

