### PR TITLE
Update retry condition to support older versions of Faraday

### DIFF
--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -44,9 +44,9 @@ module IronBank
       @connection ||= Faraday.new(faraday_config) do |conn|
         conn.use      :ddtrace, open_tracing_options if open_tracing_enabled?
         conn.use      instrumenter, instrumenter_options if instrumenter
-        conn.use      :raise_error
         conn.request  :json
-        conn.request  :retry, max: 2, retry_statuses: [401]
+        conn.request  :retry, max: 2, exceptions: [IronBank::Unauthorized]
+        conn.use      :raise_error
         conn.request  :retriable_auth, auth
         conn.response :logger, IronBank.logger
         conn.response :json, content_type: /\bjson$/

--- a/lib/iron_bank/error.rb
+++ b/lib/iron_bank/error.rb
@@ -11,6 +11,7 @@ module IronBank
       klass = begin
         case status
         when 400      then IronBank::BadRequest
+        when 401      then IronBank::Unauthorized
         when 404      then IronBank::NotFound
         when 422      then IronBank::UnprocessableEntity
         when 429      then IronBank::TooManyRequests
@@ -31,6 +32,9 @@ module IronBank
 
   # Raised when Zuora returns a 400 HTTP status code
   class BadRequest < ClientError; end
+
+  # Raised when Zuora returns a 401 HTTP status code
+  class Unauthorized < Error; end
 
   # Raised when Zuora returns a 404 HTTP status code
   class NotFound < ClientError; end

--- a/lib/iron_bank/faraday_middleware/retriable_auth.rb
+++ b/lib/iron_bank/faraday_middleware/retriable_auth.rb
@@ -25,8 +25,8 @@ module IronBank
       def renew_auth_header
         auth.renew_session
 
-        # The :retry middleware use cached request's headers which doesn't retry
-        # the request headers automatically
+        # NOTE: Merging the refreshed auth headers into the original request
+        #       (which will be retried via the `:retry` middleware.)
         env.request_headers = env.request_headers.merge(auth.header)
       end
     end

--- a/spec/iron_bank/faraday_middleware/retriable_auth_spec.rb
+++ b/spec/iron_bank/faraday_middleware/retriable_auth_spec.rb
@@ -46,11 +46,13 @@ RSpec.describe IronBank::FaradayMiddleware::RetriableAuth do
 
   private
 
+  # :reek:FeatureEnvy
   def connection
     Faraday.new do |conn|
       # To simulate a second request with new auth headers
-      conn.request :retry, max: 2, retry_statuses: [401]
+      conn.request :retry, max: 2, exceptions: [IronBank::Unauthorized]
 
+      conn.use     IronBank::FaradayMiddleware::RaiseError
       conn.use     described_class, auth
       conn.adapter :test, connection_stubs
     end


### PR DESCRIPTION
### Description

Update retry condition to support older versions of `Faraday`
- Retry status introduced with `Faraday` >= 0.15.0
- Add `IronBank::Unauthorized` error
- Retry on `IronBank::Unauthorized`

### Notes
Extra information (technical references, etc.) that you would like the reviewers
to be aware of.

### Tasks
- [x] Retry with exceptions instead of status

### Risks
Low
To support older versions of Faraday
