### PR TITLE
Rename :aka option to :alias when defining an association

### DIFF
--- a/lib/iron_bank/associations.rb
+++ b/lib/iron_bank/associations.rb
@@ -25,9 +25,8 @@ module IronBank
           end
         end
 
-        # Association is "also known as"
-        aka = options[:aka]
-        alias_method aka, name if aka
+        alias_name = options[:alias]
+        alias_method alias_name, name if alias_name
       end
 
       def with_many(name, options = {})
@@ -54,8 +53,8 @@ module IronBank
         end
 
         # Association is "also known as"
-        aka = options[:aka]
-        alias_method aka, name if aka
+        alias_name = options[:alias]
+        alias_method alias_name, name if alias_name
       end
     end
 

--- a/lib/iron_bank/associations.rb
+++ b/lib/iron_bank/associations.rb
@@ -52,7 +52,6 @@ module IronBank
           end
         end
 
-        # Association is "also known as"
         alias_name = options[:alias]
         alias_method alias_name, name if alias_name
       end

--- a/lib/iron_bank/resources/invoice.rb
+++ b/lib/iron_bank/resources/invoice.rb
@@ -23,8 +23,8 @@ module IronBank
 
       with_one :account
 
-      with_many :invoice_adjustments, aka: :adjustments
-      with_many :invoice_items, aka: :items
+      with_many :invoice_adjustments, alias: :adjustments
+      with_many :invoice_items, alias: :items
       with_many :invoice_payments
 
       # We can only retrieve one invoice body at a time, hence Body is excluded

--- a/lib/iron_bank/resources/product.rb
+++ b/lib/iron_bank/resources/product.rb
@@ -8,7 +8,7 @@ module IronBank
       with_schema
       with_local_records
       with_cache
-      with_many :product_rate_plans, aka: :plans
+      with_many :product_rate_plans, alias: :plans
     end
   end
 end

--- a/lib/iron_bank/resources/product_rate_plan.rb
+++ b/lib/iron_bank/resources/product_rate_plan.rb
@@ -16,7 +16,7 @@ module IronBank
       with_cache
 
       with_one  :product
-      with_many :product_rate_plan_charges, aka: :charges
+      with_many :product_rate_plan_charges, alias: :charges
 
       def active_currencies
         query_string = IronBank::QueryBuilder.zoql(

--- a/lib/iron_bank/resources/product_rate_plan_charge.rb
+++ b/lib/iron_bank/resources/product_rate_plan_charge.rb
@@ -19,9 +19,9 @@ module IronBank
       with_local_records
       with_cache
 
-      with_one :product_rate_plan, aka: :plan
+      with_one :product_rate_plan, alias: :plan
 
-      with_many :product_rate_plan_charge_tiers, aka: :tiers
+      with_many :product_rate_plan_charge_tiers, alias: :tiers
     end
   end
 end

--- a/lib/iron_bank/resources/product_rate_plan_charge_tier.rb
+++ b/lib/iron_bank/resources/product_rate_plan_charge_tier.rb
@@ -10,7 +10,7 @@ module IronBank
       with_local_records
       with_cache
 
-      with_one :product_rate_plan_charge, aka: :charge
+      with_one :product_rate_plan_charge, alias: :charge
 
       def self.where(conditions)
         # If we are coming from a subclass, defer to Queryable#all

--- a/lib/iron_bank/resources/rate_plan.rb
+++ b/lib/iron_bank/resources/rate_plan.rb
@@ -10,11 +10,11 @@ module IronBank
       with_cache
 
       with_one :amendment
-      with_one :product_rate_plan, aka: :catalog_plan
+      with_one :product_rate_plan, alias: :catalog_plan
       with_one :subscription
 
       with_many :rate_plan_charges,
-                aka:        :charges,
+                alias:      :charges,
                 conditions: { is_last_segment: true }
     end
   end

--- a/lib/iron_bank/resources/rate_plan_charge.rb
+++ b/lib/iron_bank/resources/rate_plan_charge.rb
@@ -21,10 +21,10 @@ module IronBank
       with_cache
 
       with_one :original, resource_name: 'RatePlanCharge'
-      with_one :product_rate_plan_charge, aka: :catalog_charge
-      with_one :rate_plan, aka: :plan
+      with_one :product_rate_plan_charge, alias: :catalog_charge
+      with_one :rate_plan, alias: :plan
 
-      with_many :rate_plan_charge_tiers, aka: :tiers
+      with_many :rate_plan_charge_tiers, alias: :tiers
     end
   end
 end

--- a/lib/iron_bank/resources/rate_plan_charge_tier.rb
+++ b/lib/iron_bank/resources/rate_plan_charge_tier.rb
@@ -20,7 +20,7 @@ module IronBank
       with_schema
       with_cache
 
-      with_one :rate_plan_charge, aka: :charge
+      with_one :rate_plan_charge, alias: :charge
     end
   end
 end

--- a/lib/iron_bank/resources/subscription.rb
+++ b/lib/iron_bank/resources/subscription.rb
@@ -17,7 +17,7 @@ module IronBank
                resource_name: 'Subscription',
                foreign_key:   'previous_subscription_id'
 
-      with_many :rate_plans, aka: :plans
+      with_many :rate_plans, alias: :plans
       with_many :usages
 
       # FIXME: a subscription can only have at most one amendment (no amendment

--- a/spec/shared_examples/associations.rb
+++ b/spec/shared_examples/associations.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'a resource with associations' do
 
   describe '::with_one' do
     before do
-      described_class.with_one :associated_object, aka: :an_object
+      described_class.with_one :associated_object, alias: :an_object
     end
 
     it 'defines an instance method and an alias to find the association' do
@@ -51,7 +51,7 @@ RSpec.shared_examples 'a resource with associations' do
 
   describe '::with_many' do
     before do
-      described_class.with_many :associated_objects, aka: :objects
+      described_class.with_many :associated_objects, alias: :objects
     end
 
     it 'defines an instance method an alias to query the association' do


### PR DESCRIPTION
### Description
This changeset renames the `:aka` (also known as) option when defining an association for `:alias` which is much clearer in the code (as proven by removing the comment explaining what `aka` stands for).

### Risks
**Low.** Internal option only, not publicly exposed (unless someone is defining a custom Zuora model, which I think is not usual).