### PR TITLE
remove Ruby 2.2.x as a supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 2.2.9
-  - 2.3.5
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 
 sudo: false
 

--- a/iron_bank.gemspec
+++ b/iron_bank.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
     'mturan@zendesk.com'
   ]
 
+  spec.required_ruby_version = '>= 2.3'
+
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
### Description
This changeset removes Ruby `2.2.x` as a supported version, as well as clean up the Travis file to only tests all three supported Ruby version.

### Risks
**Medium.** Remove unsupported Ruby version, enforce minimum Ruby version to `2.3` it in `gemspec` file.