### PR TITLE
Refactors `IronBank::Object`

### DIFF
--- a/lib/iron_bank/object.rb
+++ b/lib/iron_bank/object.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 
 module IronBank
-  # This object holds the initial payload (hash) sent through one of the
-  # action/operation. It exposes methods to convert the payload to either
-  # upper camel case (typically used by actions) or lower camel case.
+  # This object holds the initial payload sent to an action/operation. It
+  # exposes methods to convert the payload keys to either upper camel case
+  # (typically used by actions) or lower camel case.
   #
   # It is also use to parse the response from Zuora and convert it into a Ruby-
   # friendly Hash.
   #
   class Object
-    SNOWFLAKE_FIELDS = ['fieldsToNull'].freeze
+    UNMODIFIED_FIELD_KEYS = %w[
+      fieldsToNull
+    ].freeze
+
+    CAMELIZER = lambda do |type, key|
+      return key if UNMODIFIED_FIELD_KEYS.include?(key.to_s)
+
+      IronBank::Utils.camelize(key, type: type)
+    end
+
+    UNDERSCORER = lambda do |key|
+      IronBank::Utils.underscore(key).to_sym
+    end
 
     attr_reader :payload
 
@@ -17,72 +29,40 @@ module IronBank
       @payload = payload
     end
 
-    # FIXME: refactor both camelize/underscore methods into one
     def deep_camelize(type: :upper)
-      payload.each_pair.with_object({}) do |(field, value), hash|
-        field = field.to_s
+      @prok = CAMELIZER.curry[type]
 
-        key = if SNOWFLAKE_FIELDS.include?(field)
-                field
-              else
-                IronBank::Utils.camelize(field, type: type)
-              end
-
-        hash[key] = camelize(value, type: type)
-      end
+      transform(payload)
     end
 
-    # FIXME: refactor both camelize/underscore methods into one
     def deep_underscore
-      payload.each_pair.with_object({}) do |(field, value), hash|
-        key       = IronBank::Utils.underscore(field.to_s).to_sym
-        hash[key] = underscore(value)
-      end
+      @prok = UNDERSCORER
+
+      transform(payload)
     end
 
     private
 
-    # FIXME: refactor both camelize/underscore methods into one
-    def camelize(value, type: :upper)
-      if value.is_a?(Array)
-        camelize_array(value, type: type)
-      elsif value.is_a?(Hash)
-        IronBank::Object.new(value).deep_camelize(type: type)
-      elsif value.is_a?(IronBank::Object)
-        value.deep_camelize(type: type)
-      else
-        value
+    attr_reader :prok
+
+    def transform(value)
+      case value
+      when Array            then transform_array(value)
+      when Hash             then transform_hash(value)
+      when IronBank::Object then transform(value.payload)
+      else                       value
       end
     end
 
-    # FIXME: refactor both camelize/underscore methods into one
-    def camelize_array(value, type: :upper)
-      value.each.with_object([]) do |item, payload|
-        item = IronBank::Object.new(item) if item.is_a?(Hash)
-        item = item.deep_camelize(type: type) unless item.is_a?(String)
-
-        payload.push(item)
-      end
+    def transform_array(array)
+      array.map { |element| transform(element) }
     end
 
-    # FIXME: refactor both camelize/underscore methods into one
-    def underscore(value)
-      if value.is_a?(Array)
-        underscore_array(value)
-      elsif value.is_a?(Hash)
-        IronBank::Object.new(value).deep_underscore
-      elsif value.is_a?(IronBank::Object)
-        value.deep_underscore
-      else
-        value
-      end
-    end
+    def transform_hash(hash)
+      hash.each.with_object({}) do |(key, value), hsh|
+        key = prok.call(key.to_s)
 
-    # FIXME: refactor both camelize/underscore methods into one
-    def underscore_array(value)
-      value.each.with_object([]) do |item, payload|
-        item = IronBank::Object.new(item) if item.is_a?(Hash)
-        payload.push(item.deep_underscore)
+        hsh[key] = transform(value)
       end
     end
   end


### PR DESCRIPTION
### Description
Refactors the `IronBank::Object` class:
 * Extracts the camelizing/underscoring into lambdas, obviating the need for
   separate `#camelize_<type>` & `#underscore_<type>` methods
 * Reworks the type-checking to support array payloads!

### Notes
Internal refactor; no version bump required

### Risks
**Low**: Internal refactor with good unit specs.