### PR TITLE
Reworks `IronBank::Action` Arguments & Responses

### DIFF
--- a/lib/iron_bank/action.rb
+++ b/lib/iron_bank/action.rb
@@ -12,9 +12,10 @@ module IronBank
 
     def call
       @body = IronBank.client.connection.post(endpoint, params).body
-      return body if success?
 
-      raise ::IronBank::UnprocessableEntity, errors
+      raise ::IronBank::UnprocessableEntity, errors unless success?
+
+      IronBank::Object.new(body).deep_underscore
     end
 
     private
@@ -47,12 +48,6 @@ module IronBank
 
     def errors
       { errors: response_object.fetch(:errors, []) }
-    end
-
-    def requests(type: :upper)
-      args.fetch(:objects).map do |object|
-        IronBank::Object.new(object).deep_camelize(type: type)
-      end
     end
   end
 end

--- a/lib/iron_bank/actions/amend.rb
+++ b/lib/iron_bank/actions/amend.rb
@@ -6,10 +6,20 @@ module IronBank
     # https://www.zuora.com/developer/api-reference/#operation/Action_POSTamend
     #
     class Amend < Action
+      def call
+        # NOTE: The amend response wraps all results in an object, which is
+        #       inconsistent with the rest of the `/v1/action` responses.
+        super[:results]
+      end
+
       private
 
       def params
-        { requests: args }
+        { requests: requests }
+      end
+
+      def requests
+        IronBank::Object.new(args.fetch(:requests)).deep_camelize(type: :upper)
       end
     end
   end

--- a/lib/iron_bank/actions/create.rb
+++ b/lib/iron_bank/actions/create.rb
@@ -10,9 +10,17 @@ module IronBank
 
       def params
         {
-          objects: requests,
-          type:    args.fetch(:type)
+          objects: objects,
+          type:    type
         }
+      end
+
+      def objects
+        IronBank::Object.new(args.fetch(:objects)).deep_camelize(type: :upper)
+      end
+
+      def type
+        IronBank::Utils.camelize(args.fetch(:type), type: :upper)
       end
     end
   end

--- a/lib/iron_bank/actions/delete.rb
+++ b/lib/iron_bank/actions/delete.rb
@@ -11,8 +11,12 @@ module IronBank
       def params
         {
           ids:  args.fetch(:ids),
-          type: args.fetch(:type)
+          type: type
         }
+      end
+
+      def type
+        IronBank::Utils.camelize(args.fetch(:type), type: :upper)
       end
     end
   end

--- a/lib/iron_bank/actions/execute.rb
+++ b/lib/iron_bank/actions/execute.rb
@@ -13,8 +13,12 @@ module IronBank
         {
           ids:         args.fetch(:ids),
           synchronous: args.fetch(:synchronous),
-          type:        args.fetch(:type)
+          type:        type
         }
+      end
+
+      def type
+        IronBank::Utils.camelize(args.fetch(:type), type: :upper)
       end
     end
   end

--- a/lib/iron_bank/actions/generate.rb
+++ b/lib/iron_bank/actions/generate.rb
@@ -10,9 +10,17 @@ module IronBank
 
       def params
         {
-          objects: args.fetch(:objects).map(&:deep_camelize),
-          type:    args.fetch(:type)
+          objects: objects,
+          type:    type
         }
+      end
+
+      def objects
+        IronBank::Object.new(args.fetch(:objects)).deep_camelize(type: :upper)
+      end
+
+      def type
+        IronBank::Utils.camelize(args.fetch(:type), type: :upper)
       end
     end
   end

--- a/lib/iron_bank/actions/query.rb
+++ b/lib/iron_bank/actions/query.rb
@@ -9,7 +9,7 @@ module IronBank
       private
 
       def params
-        { 'queryString' => args }
+        { 'queryString': args }
       end
     end
   end

--- a/lib/iron_bank/actions/query_more.rb
+++ b/lib/iron_bank/actions/query_more.rb
@@ -9,7 +9,7 @@ module IronBank
       private
 
       def params
-        { 'queryLocator' => args }
+        { 'queryLocator': args }
       end
 
       # NOTE: Zuora API endpoint is case-sensitive.

--- a/lib/iron_bank/actions/subscribe.rb
+++ b/lib/iron_bank/actions/subscribe.rb
@@ -7,25 +7,14 @@ module IronBank
     # https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe
     #
     class Subscribe < Action
-      def call
-        body = IronBank.client.connection.post(endpoint, params).body
-
-        if body.is_a?(Array)
-          body.map { |result| IronBank::Object.new(result).deep_underscore }
-        else
-          IronBank::Object.new(body).deep_underscore
-        end
-      end
-
       private
 
       def params
-        { subscribes: subscribe_requests }
+        { subscribes: subscribes }
       end
 
-      def subscribe_requests
-        requests = [args].flatten
-        requests.map { |request| IronBank::Object.new(request).deep_camelize }
+      def subscribes
+        IronBank::Object.new(args.fetch(:subscribes)).deep_camelize
       end
     end
   end

--- a/lib/iron_bank/actions/update.rb
+++ b/lib/iron_bank/actions/update.rb
@@ -10,9 +10,17 @@ module IronBank
 
       def params
         {
-          objects: requests,
-          type:    args.fetch(:type)
+          objects: objects,
+          type:    type
         }
+      end
+
+      def objects
+        IronBank::Object.new(args.fetch(:objects)).deep_camelize(type: :upper)
+      end
+
+      def type
+        IronBank::Utils.camelize(args.fetch(:type), type: :upper)
       end
     end
   end

--- a/spec/iron_bank/action_spec.rb
+++ b/spec/iron_bank/action_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe IronBank::Action do
         ]
       end
 
-      it { expect(call).to eq(body) }
+      it { expect(call).to eq(IronBank::Object.new(body).deep_underscore) }
     end
 
     context 'with params on failure' do

--- a/spec/iron_bank/actions/amend_spec.rb
+++ b/spec/iron_bank/actions/amend_spec.rb
@@ -5,8 +5,26 @@ require 'shared_examples/action'
 
 RSpec.describe IronBank::Actions::Amend do
   it_behaves_like 'a Zuora action' do
-    let(:args)     { anything }
+    let(:args) do
+      {
+        requests: [
+          { amendments: [], preview_options: {} },
+          { amendments: [], preview_options: {} }
+        ]
+      }
+    end
+
     let(:endpoint) { 'v1/action/amend' }
-    let(:params)   { { requests: args } }
+
+    let(:params) do
+      {
+        requests: [
+          { 'Amendments' => [], 'PreviewOptions' => {} },
+          { 'Amendments' => [], 'PreviewOptions' => {} }
+        ]
+      }
+    end
+
+    let(:body) { { 'results' => anything } }
   end
 end

--- a/spec/iron_bank/actions/create_spec.rb
+++ b/spec/iron_bank/actions/create_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IronBank::Actions::Create do
   it_behaves_like 'a Zuora action' do
     let(:args) do
       {
-        type:    'Account',
+        type:    :account,
         objects: [
           { name: 'test-account-1' },
           { name: 'test-account-2' }
@@ -25,6 +25,13 @@ RSpec.describe IronBank::Actions::Create do
           { 'Name' => 'test-account-2' }
         ]
       }
+    end
+
+    let(:body) do
+      [
+        { 'Success' => true, 'Id' => 'id-1' },
+        { 'Success' => true, 'Id' => 'id-2' }
+      ]
     end
   end
 end

--- a/spec/iron_bank/actions/delete_spec.rb
+++ b/spec/iron_bank/actions/delete_spec.rb
@@ -5,15 +5,15 @@ require 'shared_examples/action'
 
 RSpec.describe IronBank::Actions::Delete do
   it_behaves_like 'a Zuora action' do
-    let(:args) do
-      {
-        ids:  ['zuora-id-123', 'zuora-id-234'],
-        type: 'Account'
-      }
-    end
-
+    let(:args)     { { type: :account, ids: %w[id-1 id-2] } }
     let(:endpoint) { 'v1/action/delete' }
+    let(:params)   { { type: 'Account', ids: %w[id-1 id-2] } }
 
-    let(:params) { args }
+    let(:body) do
+      [
+        { 'Success' => true, 'Id' => 'id-1' },
+        { 'Success' => true, 'Id' => 'id-2' }
+      ]
+    end
   end
 end

--- a/spec/iron_bank/actions/execute_spec.rb
+++ b/spec/iron_bank/actions/execute_spec.rb
@@ -7,13 +7,20 @@ RSpec.describe IronBank::Actions::Execute do
   it_behaves_like 'a Zuora action' do
     let(:args) do
       {
-        ids:         ['zuora-id-123', 'zuora-id-234', 'zuora-id-345'],
+        ids:         %w[zuora-id-123 zuora-id-234 zuora-id-345],
         synchronous: false,
-        type:        'InvoiceSplit'
+        type:        :invoice_split
       }
     end
 
     let(:endpoint) { 'v1/action/execute' }
-    let(:params)   { args }
+
+    let(:params) do
+      {
+        ids:         %w[zuora-id-123 zuora-id-234 zuora-id-345],
+        synchronous: false,
+        type:        'InvoiceSplit'
+      }
+    end
   end
 end

--- a/spec/iron_bank/actions/generate_spec.rb
+++ b/spec/iron_bank/actions/generate_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe IronBank::Actions::Generate do
   it_behaves_like 'a Zuora action' do
     let(:args) do
       {
-        type:    'Invoice',
+        type:    :invoice,
         objects: [
-          IronBank::Object.new(
+          {
             account_id:   'zuora-account-123',
             invoice_date: '2017-10-20',
             target_date:  '2017-10-20'
-          ),
-          IronBank::Object.new(
+          },
+          {
             account_id:   'zuora-account-234',
             invoice_date: '2017-10-21',
             target_date:  '2017-10-21'
-          )
+          }
         ]
       }
     end

--- a/spec/iron_bank/actions/query_more_spec.rb
+++ b/spec/iron_bank/actions/query_more_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe IronBank::Actions::QueryMore do
   it_behaves_like 'a Zuora action' do
     let(:args)     { anything }
     let(:endpoint) { 'v1/action/queryMore' }
-    let(:params)   { { 'queryLocator' => args } }
+    let(:params)   { { 'queryLocator': args } }
   end
 end

--- a/spec/iron_bank/actions/query_spec.rb
+++ b/spec/iron_bank/actions/query_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe IronBank::Actions::Query do
   it_behaves_like 'a Zuora action' do
     let(:args)     { anything }
     let(:endpoint) { 'v1/action/query' }
-    let(:params)   { { 'queryString' => args } }
+    let(:params)   { { 'queryString': args } }
   end
 end

--- a/spec/iron_bank/actions/subscribe_spec.rb
+++ b/spec/iron_bank/actions/subscribe_spec.rb
@@ -5,10 +5,24 @@ require 'shared_examples/action'
 
 RSpec.describe IronBank::Actions::Subscribe do
   it_behaves_like 'a Zuora action' do
-    let(:args)              { { dummy: true } }
-    let(:response_body)     { { success: true } }
-    let(:endpoint)          { 'v1/action/subscribe' }
-    let(:subscribe_request) { IronBank::Object.new(args).deep_camelize }
-    let(:params)            { { subscribes: [subscribe_request] } }
+    let(:args) do
+      {
+        subscribes: [
+          { account: {}, subscribe_options: {} },
+          { account: {}, subscribe_options: {} }
+        ]
+      }
+    end
+
+    let(:endpoint) { 'v1/action/subscribe' }
+
+    let(:params) do
+      {
+        subscribes: [
+          { 'Account' => {}, 'SubscribeOptions' => {} },
+          { 'Account' => {}, 'SubscribeOptions' => {} }
+        ]
+      }
+    end
   end
 end

--- a/spec/iron_bank/actions/update_spec.rb
+++ b/spec/iron_bank/actions/update_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IronBank::Actions::Update do
   it_behaves_like 'a Zuora action' do
     let(:args) do
       {
-        type:    'Account',
+        type:    :account,
         objects: [
           { id: 'some-zuora-id-123', name: 'new-name-1' },
           { id: 'some-zuora-id-234', name: 'new-name-2' }

--- a/spec/shared_examples/action.rb
+++ b/spec/shared_examples/action.rb
@@ -1,20 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'a Zuora action' do
-  let(:connection)    { instance_double(Faraday::Connection) }
-  let(:response_body) { anything }
-
-  let(:response) do
-    instance_double(Faraday::Response, body: response_body)
-  end
-
-  let(:client) do
-    instance_double(IronBank::Client, connection: connection)
-  end
+  let(:client)     { instance_double(IronBank::Client) }
+  let(:connection) { instance_double(Faraday::Connection) }
+  let(:response)   { instance_double(Faraday::Response, body: body) }
+  let(:body)       { [{}] }
 
   describe '::call' do
     before do
       allow(IronBank).to receive(:client).and_return(client)
+      allow(client).to receive(:connection).and_return(connection)
     end
 
     subject(:call) { described_class.call(args) }


### PR DESCRIPTION
### Description
Reworks the `IronBank::Action` classes to accept & return underscored hashes
(handling the camel-case conversion transparently to the caller.)

### Blocked By
 - [x] https://github.com/zendesk/iron_bank/pull/11

### Notes
Likely requires a major version bump, as the responses for all actions have
been changed (underscored.)

### Risks
**High:** Reworks the args & returned values for all actions.