### PR TITLE
header converter

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -87,6 +87,10 @@ detectors:
       - IronBank::Resources::ProductRatePlanChargeTier#self.load_records
       - IronBank::Error#self.from_response
 
+  UncommunicativeVariableName:
+    exclude:
+      - IronBank::Local#csv_options
+
   UtilityFunction:
     exclude:
       - IronBank::Cacheable::ClassMethods#cache

--- a/lib/iron_bank/local.rb
+++ b/lib/iron_bank/local.rb
@@ -51,15 +51,9 @@ module IronBank
     def csv_options
       {
         headers:           true,
-        header_converters: header_converters,
+        header_converters: [->(h) { IronBank::Utils.underscore(h).to_sym }],
         converters:        csv_converters
       }
-    end
-
-    def header_converters
-      %i[
-        symbol
-      ]
     end
 
     def csv_converters

--- a/lib/iron_bank/local_records.rb
+++ b/lib/iron_bank/local_records.rb
@@ -25,7 +25,7 @@ module IronBank
     def export
       CSV.open(file_path, 'w') do |csv|
         # first row = CSV headers
-        csv << klass.fields.map { |field| IronBank::Utils.underscore(field) }
+        write_headers(csv)
         write_records(csv)
       end
     end
@@ -44,6 +44,10 @@ module IronBank
 
     def file_path
       File.expand_path("#{resource}.csv", self.class.directory)
+    end
+
+    def write_headers(csv)
+      csv << klass.fields
     end
 
     def write_records(csv)


### PR DESCRIPTION
@mickaelpham @rringler 
### Description
the ruby build in symbol header convert will strip the underscore from header:  https://github.com/ruby/ruby/blob/ruby_2_3/lib/csv.rb#L985-L987

we only want to convert the string to symbol

### Risks
**Low** 
