### PR TITLE
[WALR-765] Update instrumentation for IronBank (trace per endpoint)

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -54,6 +54,7 @@ detectors:
   ManualDispatch:
     exclude:
       - IronBank::Resource#inspect
+      - IronBank::Instrumentation#datadog_instrumenter
 
   NestedIterators:
     exclude:
@@ -104,3 +105,4 @@ detectors:
       - IronBank::Utils#upper_camelize
       - IronBank::Instrumentation#instrumenter
       - IronBank::Instrumentation#instrumenter_options
+      - IronBank::Instrumentation#datadog_instrumenter

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/AbcSize:
   Exclude:
     - lib/iron_bank/associations.rb
     - lib/iron_bank/client.rb
+    - lib/iron_bank/action.rb
 
 Metrics/BlockLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
 
 before_install:
   - gem update --system
-  - gem install bundler
+  - gem install -v 1.16.6 bundler
 
 env:
   global:

--- a/lib/iron_bank/action.rb
+++ b/lib/iron_bank/action.rb
@@ -4,6 +4,8 @@ module IronBank
   # Base class for Zuora actions, e.g., subscribe
   #
   class Action
+    include IronBank::Instrumentation
+
     private_class_method :new
 
     def self.call(args)
@@ -11,11 +13,13 @@ module IronBank
     end
 
     def call
-      @body = IronBank.client.connection.post(endpoint, params).body
+      datadog_instrumenter(name.downcase) do
+        @body = IronBank.client.connection.post(endpoint, params).body
 
-      raise ::IronBank::UnprocessableEntity, errors unless success?
+        raise ::IronBank::UnprocessableEntity, errors unless success?
 
-      IronBank::Object.new(body).deep_underscore
+        IronBank::Object.new(body).deep_underscore
+      end
     end
 
     private

--- a/lib/iron_bank/instrumentation.rb
+++ b/lib/iron_bank/instrumentation.rb
@@ -10,5 +10,21 @@ module IronBank
     def instrumenter_options
       IronBank.configuration.instrumenter_options || {}
     end
+
+    DDTRACE_NAME          = 'billing-ironbank'.freeze
+    DDTRACE_SERVICE_NAME  = 'billing-ironbank-client'.freeze
+
+    def datadog_instrumenter(name)
+      if defined?(Datadog) && Datadog.respond_to?(:tracer)
+        trace_options = {
+          service:  DDTRACE_SERVICE_NAME,
+          resource: name.to_s
+        }
+
+        Datadog.tracer.trace(DDTRACE_NAME, trace_options) { yield }
+      else
+        yield
+      end
+    end
   end
 end

--- a/lib/iron_bank/instrumentation.rb
+++ b/lib/iron_bank/instrumentation.rb
@@ -11,8 +11,8 @@ module IronBank
       IronBank.configuration.instrumenter_options || {}
     end
 
-    DDTRACE_NAME          = 'billing-ironbank'.freeze
-    DDTRACE_SERVICE_NAME  = 'billing-ironbank-client'.freeze
+    DDTRACE_NAME          = 'billing-ironbank'
+    DDTRACE_SERVICE_NAME  = 'billing-ironbank-client'
 
     def datadog_instrumenter(name)
       if defined?(Datadog) && Datadog.respond_to?(:tracer)

--- a/lib/iron_bank/queryable.rb
+++ b/lib/iron_bank/queryable.rb
@@ -4,15 +4,18 @@ module IronBank
   # Query-like features, such as `find` and `where` methods for a resource.
   #
   module Queryable
+    include IronBank::Instrumentation
+
     # We use the REST endpoint for the `find` method
     def find(id)
       raise IronBank::NotFound unless id
 
-      response = IronBank.client.connection.get(
-        "v1/object/#{object_name}/#{id}"
-      )
-
-      new(IronBank::Object.new(response.body).deep_underscore)
+      datadog_instrumenter(:find) do
+        response = IronBank.client.connection.get(
+          "v1/object/#{object_name}/#{id}"
+        )
+        new(IronBank::Object.new(response.body).deep_underscore)
+      end
     end
 
     # This methods leverages the fact that Zuora only returns 2,000 records at a

--- a/spec/iron_bank/instrumentation_spec.rb
+++ b/spec/iron_bank/instrumentation_spec.rb
@@ -35,6 +35,44 @@ RSpec.describe IronBank::Instrumentation do
     end
   end
 
+  describe '#datadog_instrumenter' do
+    subject(:datadog_instrumenter) { instance.datadog_instrumenter(:find) {} }
+
+    let(:dd_client) { instance_double(Datadog::Tracer) }
+
+    context 'when datadog is configured' do
+      let(:expected_options) do
+        {
+          service:  'billing-ironbank-client',
+          resource: 'find'
+        }
+      end
+
+      before do
+        allow(Datadog).to receive(:tracer).and_return(dd_client)
+      end
+
+      specify do
+        expect(dd_client).to receive(:trace).
+          with('billing-ironbank', expected_options)
+
+        datadog_instrumenter
+      end
+    end
+
+    context 'when datadog is not configured' do
+      before do
+        allow(Datadog).to receive(:respond_to?).and_return(nil)
+      end
+
+      it 'wont trace/instrument' do
+        expect(dd_client).not_to receive(:trace)
+
+        datadog_instrumenter
+      end
+    end
+  end
+
   describe '#instrumenter_options' do
     subject(:instrumenter_options) { instance.instrumenter_options }
 


### PR DESCRIPTION
@zendesk/billing @mickaelpham @dlugo06 

### Description
* datadog instrumentation for ironbank operations

### Notes
[WALR-765 Update instrumentation for IronBank (trace per endpoint)](https://zendesk.atlassian.net/browse/WALR-765)

### Tasks
- [ ] Verify no iron bank operation is impacted in staging
- [ ] BITS to go green

### Risks
*High*
It adds datadog instrumentation, might impact ironbank operations


[WALR-765]: https://zendesk.atlassian.net/browse/WALR-765