### PR TITLE
Updates `IronBank::Error.from_response` To Inspect the Response Body

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -64,9 +64,7 @@ detectors:
       - IronBank::Resources::ProductRatePlanChargeTier#self.load_records
 
   NilCheck:
-    exclude:
-      - IronBank::Local#load_records
-      - IronBank::Resources::ProductRatePlanChargeTier#self.load_records
+    enabled: false
 
   TooManyInstanceVariables:
     max_instance_variables: 6

--- a/.reek.yml
+++ b/.reek.yml
@@ -80,6 +80,7 @@ detectors:
       - IronBank::Client#connection
       - IronBank::Configuration#schema_directory=
       - IronBank::Configuration#initialize
+      - IronBank::Error#message_from_body
       - IronBank::Queryable#find_each
       - IronBank::Queryable#where
       - IronBank::Utils#camelize

--- a/iron_bank.gemspec
+++ b/iron_bank.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bump',             '~> 0.5'
-  spec.add_development_dependency 'bundler',          '~> 1.15'
+  spec.add_development_dependency 'bundler',          '~> 2.0'
   spec.add_development_dependency 'dotenv',           '~> 2.2'
   spec.add_development_dependency 'factory_bot',      '~> 4.10'
   spec.add_development_dependency 'pry-byebug',       '~> 3.4'

--- a/lib/iron_bank.rb
+++ b/lib/iron_bank.rb
@@ -58,7 +58,7 @@ require 'iron_bank/version'
 require 'iron_bank/csv'
 require 'iron_bank/error'
 require 'iron_bank/faraday_middleware/raise_error'
-require 'iron_bank/faraday_middleware/retriable_auth'
+require 'iron_bank/faraday_middleware/renew_auth'
 require 'iron_bank/faraday_middleware'
 
 # Helpers

--- a/lib/iron_bank/action.rb
+++ b/lib/iron_bank/action.rb
@@ -13,7 +13,7 @@ module IronBank
     def call
       @body = IronBank.client.connection.post(endpoint, params).body
 
-      raise ::IronBank::UnprocessableEntity, errors unless success?
+      raise ::IronBank::UnprocessableEntityError, errors unless success?
 
       IronBank::Object.new(body).deep_underscore
     end

--- a/lib/iron_bank/error.rb
+++ b/lib/iron_bank/error.rb
@@ -6,24 +6,42 @@ module IronBank
     # Returns the appropriate IronBank::Error subclass based on status and
     # response message
     def self.from_response(response)
-      status = response[:status].to_i
-
       klass = begin
-        case status
-        when 400      then IronBank::BadRequest
-        when 401      then IronBank::Unauthorized
-        when 404      then IronBank::NotFound
-        when 422      then IronBank::UnprocessableEntity
-        when 429      then IronBank::TooManyRequests
+        case response.status
+        when 200      then from_body(response)
+        when 400      then IronBank::BadRequestError
+        when 401      then IronBank::UnauthorizedError
+        when 404      then IronBank::NotFoundError
+        when 422      then IronBank::UnprocessableEntityError
+        when 429      then IronBank::TooManyRequestsError
         when 500      then IronBank::InternalServerError
         when 400..499 then IronBank::ClientError
         when 500..599 then IronBank::ServerError
+        else               IronBank::Error
         end
       end
 
-      return unless klass
+      klass&.new(response)
+    end
 
-      klass.new(response)
+    def self.from_body(response)
+      return unless (match = CODE_MATCHER.match(response.body.to_s))
+
+      CODE_CLASSES[match.captures.first]
+    end
+
+    attr_reader :response
+
+    def initialize(response = nil)
+      @response = response
+
+      message = response.is_a?(Faraday::Response) ? message_from_body : response
+
+      super(message)
+    end
+
+    def message_from_body
+      response && "Body: #{response.body}"
     end
   end
 
@@ -31,23 +49,57 @@ module IronBank
   class ClientError < Error; end
 
   # Raised when Zuora returns a 400 HTTP status code
-  class BadRequest < ClientError; end
+  class BadRequestError < ClientError; end
 
   # Raised when Zuora returns a 401 HTTP status code
-  class Unauthorized < Error; end
+  class UnauthorizedError < ClientError; end
 
   # Raised when Zuora returns a 404 HTTP status code
-  class NotFound < ClientError; end
+  class NotFoundError < ClientError; end
+
+  # Zuora doesn't return a 409, but indicates it via the response
+  class ConflictError < ClientError; end
 
   # Raised when Zuora return 422 and unsuccessful action responses
-  class UnprocessableEntity < Error; end
+  class UnprocessableEntityError < ClientError; end
 
   # Raised when Zuora returns a 429 HTTP status code
-  class TooManyRequests < ClientError; end
+  class TooManyRequestsError < ClientError; end
 
   # Raised on errors in the 500-599 range
   class ServerError < Error; end
 
   # Raised when Zuora returns a 500 HTTP status code
   class InternalServerError < ServerError; end
+
+  # Zuora doesn't return a 502, but indicates it via the response
+  class BadGatewayError < ServerError; end
+
+  # Zuora indicates a temporary error via the response
+  class TemporaryError < ServerError; end
+
+  # Zuora indicates lock competition errors via the response
+  class LockCompetitionError < TemporaryError; end
+
+  CODE_CLASSES = {
+    'API_DISABLED'           => ServerError,
+    'CANNOT_DELETE'          => UnprocessableEntityError,
+    'DUPLICATE_VALUE'        => ConflictError,
+    'INVALID_FIELD'          => BadRequestError,
+    'INVALID_ID'             => BadRequestError,
+    'INVALID_TYPE'           => BadRequestError,
+    'INVALID_VALUE'          => BadRequestError,
+    'LOCK_COMPETITION'       => LockCompetitionError,
+    'MALFORMED_QUERY'        => ClientError,
+    'MISSING_REQUIRED_VALUE' => ClientError,
+    'REQUEST_EXCEEDED_LIMIT' => TooManyRequestsError,
+    'REQUEST_EXCEEDED_RATE'  => TooManyRequestsError,
+    'TEMPORARY_ERROR'        => TemporaryError,
+    'TRANSACTION_FAILED'     => InternalServerError,
+    'TRANSACTION_TERMINATED' => InternalServerError,
+    'TRANSACTION_TIMEOUT'    => BadGatewayError,
+    'UNKNOWN_ERROR'          => InternalServerError
+  }.freeze
+
+  CODE_MATCHER = /(#{CODE_CLASSES.keys.join('|')})/.freeze
 end

--- a/lib/iron_bank/faraday_middleware.rb
+++ b/lib/iron_bank/faraday_middleware.rb
@@ -4,12 +4,11 @@
 module IronBank
   # IronBank Faraday middleware module
   module FaradayMiddleware
-    if Faraday::Middleware.respond_to? :register_middleware
-      Faraday::Middleware.register_middleware \
-        raise_error: -> { RaiseError }
-
-      Faraday::Request.register_middleware \
-        retriable_auth: -> { RetriableAuth }
+    if Faraday::Middleware.respond_to?(:register_middleware)
+      Faraday::Response.register_middleware(
+        raise_error: -> { RaiseError },
+        renew_auth:  -> { RenewAuth }
+      )
     end
   end
 end

--- a/lib/iron_bank/faraday_middleware/raise_error.rb
+++ b/lib/iron_bank/faraday_middleware/raise_error.rb
@@ -9,8 +9,8 @@ module IronBank
     class RaiseError < Faraday::Response::Middleware
       private
 
-      def on_complete(response)
-        (error = IronBank::Error.from_response(response)) && raise(error)
+      def on_complete(env)
+        (error = IronBank::Error.from_response(env.response)) && raise(error)
       end
     end
   end

--- a/lib/iron_bank/faraday_middleware/renew_auth.rb
+++ b/lib/iron_bank/faraday_middleware/renew_auth.rb
@@ -5,17 +5,17 @@ module IronBank
   # IronBank Faraday middleware module
   module FaradayMiddleware
     # This middleware reauthorize the request on unauthorized request
-    class RetriableAuth < Faraday::Middleware
+    class RenewAuth < Faraday::Response::Middleware
       def initialize(app, auth)
         @auth = auth
+
         super(app)
       end
 
-      def call(env)
+      def on_complete(env)
         @env = env
-        renew_auth_header if env.status == 401
 
-        @app.call(env)
+        renew_auth_header if env.status == 401
       end
 
       private

--- a/lib/iron_bank/queryable.rb
+++ b/lib/iron_bank/queryable.rb
@@ -6,7 +6,7 @@ module IronBank
   module Queryable
     # We use the REST endpoint for the `find` method
     def find(id)
-      raise IronBank::NotFound unless id
+      raise IronBank::NotFoundError unless id
 
       response = IronBank.client.connection.get(
         "v1/object/#{object_name}/#{id}"

--- a/spec/iron_bank/action_spec.rb
+++ b/spec/iron_bank/action_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe IronBank::Action do
       end
 
       specify do
-        expect { call }.to raise_error(IronBank::UnprocessableEntity)
+        expect { call }.to raise_error(IronBank::UnprocessableEntityError)
       end
     end
   end

--- a/spec/iron_bank/error_spec.rb
+++ b/spec/iron_bank/error_spec.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe IronBank::Error do
+  describe '::from_response' do
+    let(:response) { instance_double(Faraday::Response) }
+
+    before do
+      allow(response).to receive(:status).
+        and_return(status)
+    end
+
+    subject(:error) { described_class.from_response(response) }
+
+    shared_examples 'returning the correct error' do
+      it { is_expected.to be_a(expected_error) }
+    end
+
+    context 'for a response with a 200 status code' do
+      let(:status) { 200 }
+
+      it 'delegates to ::from_body' do
+        expect(described_class).to receive(:from_body)
+
+        subject
+      end
+    end
+
+    context 'for a response with a 400 status code' do
+      let(:status)         { 400 }
+      let(:expected_error) { IronBank::BadRequestError }
+
+      it_behaves_like 'returning the correct error'
+    end
+
+    context 'for a response with a 401 status code' do
+      let(:status)         { 401 }
+      let(:expected_error) { IronBank::UnauthorizedError }
+
+      it_behaves_like 'returning the correct error'
+    end
+
+    context 'for a response with a 404 status code' do
+      let(:status)         { 404 }
+      let(:expected_error) { IronBank::NotFoundError }
+
+      it_behaves_like 'returning the correct error'
+    end
+
+    context 'for a response with a 422 status code' do
+      let(:status)         { 422 }
+      let(:expected_error) { IronBank::UnprocessableEntityError }
+
+      it_behaves_like 'returning the correct error'
+    end
+
+    context 'for a response with a 429 status code' do
+      let(:status)         { 429 }
+      let(:expected_error) { IronBank::TooManyRequestsError }
+
+      it_behaves_like 'returning the correct error'
+    end
+
+    context 'for a response with a 500 status code' do
+      let(:status)         { 500 }
+      let(:expected_error) { IronBank::InternalServerError }
+
+      it_behaves_like 'returning the correct error'
+    end
+
+    context 'for a response with any other 400 status code' do
+      let(:status)         { 499 }
+      let(:expected_error) { IronBank::ClientError }
+
+      it_behaves_like 'returning the correct error'
+    end
+
+    context 'for a response with any other 500 status code' do
+      let(:status)         { 599 }
+      let(:expected_error) { IronBank::ServerError }
+
+      it_behaves_like 'returning the correct error'
+    end
+
+    context 'for a response with any other status code' do
+      let(:status)         { 600 }
+      let(:expected_error) { IronBank::Error }
+
+      it_behaves_like 'returning the correct error'
+    end
+  end
+
+  describe '::from_body' do
+    let(:response) { instance_double(Faraday::Response) }
+    let(:body)     { "CODE: #{code}" }
+
+    before do
+      allow(response).to receive(:body).
+        and_return(body)
+    end
+
+    subject(:error) { described_class.from_body(response) }
+
+    shared_examples 'returning the correct error class' do
+      it { is_expected.to eq(expected_error) }
+    end
+
+    context 'for a body with a `API_DISABLED` code' do
+      let(:code)           { 'API_DISABLED' }
+      let(:expected_error) { IronBank::ServerError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `CANNOT_DELETE` code' do
+      let(:code)           { 'CANNOT_DELETE' }
+      let(:expected_error) { IronBank::UnprocessableEntityError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `DUPLICATE_VALUE` code' do
+      let(:code)           { 'DUPLICATE_VALUE' }
+      let(:expected_error) { IronBank::ConflictError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `INVALID_FIELD` code' do
+      let(:code)           { 'INVALID_FIELD' }
+      let(:expected_error) { IronBank::BadRequestError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `INVALID_ID` code' do
+      let(:code)           { 'INVALID_ID' }
+      let(:expected_error) { IronBank::BadRequestError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `INVALID_TYPE` code' do
+      let(:code)           { 'INVALID_TYPE' }
+      let(:expected_error) { IronBank::BadRequestError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `INVALID_VALUE` code' do
+      let(:code)           { 'INVALID_VALUE' }
+      let(:expected_error) { IronBank::BadRequestError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `LOCK_COMPETITION` code' do
+      let(:code)           { 'LOCK_COMPETITION' }
+      let(:expected_error) { IronBank::LockCompetitionError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `MALFORMED_QUERY` code' do
+      let(:code)           { 'MALFORMED_QUERY' }
+      let(:expected_error) { IronBank::ClientError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `MISSING_REQUIRED_VALUE` code' do
+      let(:code)           { 'MISSING_REQUIRED_VALUE' }
+      let(:expected_error) { IronBank::ClientError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `REQUEST_EXCEEDED_LIMIT` code' do
+      let(:code)           { 'REQUEST_EXCEEDED_LIMIT' }
+      let(:expected_error) { IronBank::TooManyRequestsError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `REQUEST_EXCEEDED_RATE` code' do
+      let(:code)           { 'REQUEST_EXCEEDED_RATE' }
+      let(:expected_error) { IronBank::TooManyRequestsError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `TEMPORARY_ERROR` code' do
+      let(:code)           { 'TEMPORARY_ERROR' }
+      let(:expected_error) { IronBank::TemporaryError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `TRANSACTION_FAILED` code' do
+      let(:code)           { 'TRANSACTION_FAILED' }
+      let(:expected_error) { IronBank::InternalServerError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `TRANSACTION_TERMINATED` code' do
+      let(:code)           { 'TRANSACTION_TERMINATED' }
+      let(:expected_error) { IronBank::InternalServerError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `TRANSACTION_TIMEOUT` code' do
+      let(:code)           { 'TRANSACTION_TIMEOUT' }
+      let(:expected_error) { IronBank::BadGatewayError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+
+    context 'for a body with a `UNKNOWN_ERROR` code' do
+      let(:code)           { 'UNKNOWN_ERROR' }
+      let(:expected_error) { IronBank::InternalServerError }
+
+      it_behaves_like 'returning the correct error class'
+    end
+  end
+end

--- a/spec/iron_bank/faraday_middleware/renew_auth_spec.rb
+++ b/spec/iron_bank/faraday_middleware/renew_auth_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe IronBank::FaradayMiddleware::RetriableAuth do
+RSpec.describe IronBank::FaradayMiddleware::RenewAuth do
   let(:session)         { instance_double(IronBank::Authentications::Token) }
   let(:auth)            { instance_double(IronBank::Authentication) }
   let(:new_auth_header) { { 'Authorization' => 'Bearer foo' } }
@@ -50,10 +50,11 @@ RSpec.describe IronBank::FaradayMiddleware::RetriableAuth do
   def connection
     Faraday.new do |conn|
       # To simulate a second request with new auth headers
-      conn.request :retry, max: 2, exceptions: [IronBank::Unauthorized]
+      conn.request :retry, max: 2, exceptions: [IronBank::UnauthorizedError]
 
-      conn.use     IronBank::FaradayMiddleware::RaiseError
-      conn.use     described_class, auth
+      conn.response :raise_error
+      conn.response :renew_auth, auth
+
       conn.adapter :test, connection_stubs
     end
   end

--- a/spec/shared_examples/queryable.rb
+++ b/spec/shared_examples/queryable.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples 'a queryable resource' do
       let(:id) { nil }
 
       it 'raises IronBank::NotFound error' do
-        expect { subject }.to raise_error(IronBank::NotFound)
+        expect { subject }.to raise_error(IronBank::NotFoundError)
       end
     end
   end


### PR DESCRIPTION
### Description
Updates `IronBankError.from_response` to inspect the response body, as many of
Zuora's errors are return with a 200 status code, and are indicated in the body.

### Risks
**Low**: Adds additional specificity to error-handling.
