### PR TITLE
Updates `IronBank::Client` to Fetch Retry Options From Configuration

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -20,6 +20,7 @@ detectors:
       - IronBank::Configuration#logger
       - IronBank::Configuration#open_tracing_enabled
       - IronBank::Configuration#open_tracing_service_name
+      - IronBank::Configuration#retry_options
       - IronBank::Configuration#schema_directory
 
   BooleanParameter:
@@ -68,6 +69,8 @@ detectors:
 
   TooManyInstanceVariables:
     max_instance_variables: 6
+    exclude:
+      - IronBank::Configuration
 
   TooManyStatements:
     exclude:

--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -16,12 +16,6 @@ module IronBank
     #
     class InvalidHostname < Error; end
 
-    RETRIABLE_ERRORS = [
-      IronBank::LockCompetitionError,
-      IronBank::TemporaryError,
-      IronBank::UnauthorizedError
-    ].freeze
-
     # Alias each actions as a `Client` instance method
     IronBank::Actions.constants.each do |action|
       method_name = IronBank::Utils.underscore(action)
@@ -47,18 +41,9 @@ module IronBank
       validate_domain
       reset_connection if auth.expired?
 
-      retry_options = {
-        max:                 4,
-        interval:            0.1,
-        interval_randomness: 0.05,
-        backoff_factor:      5,
-        exceptions:          RETRIABLE_ERRORS,
-        retry_if:            ->(_, ex) { RETRIABLE_ERRORS.include?(ex.class) }
-      }
-
       @connection ||= Faraday.new(faraday_config) do |conn|
         conn.request  :json
-        conn.request  :retry, retry_options
+        conn.request  :retry, IronBank.configuration.retry_options
 
         conn.response :raise_error
         conn.response :renew_auth, auth
@@ -77,6 +62,23 @@ module IronBank
     end
 
     private
+
+    DEFAULT_RETRY_OPTIONS = begin
+      retriable_errors = [
+        IronBank::LockCompetitionError,
+        IronBank::TemporaryError,
+        IronBank::UnauthorizedError
+      ]
+
+      {
+        max:                 4,
+        interval:            0.1,
+        interval_randomness: 0.05,
+        backoff_factor:      5,
+        exceptions:          retriable_errors,
+        retry_if:            ->(_, ex) { retriable_errors.include?(ex.class) }
+      }
+    end.freeze
 
     attr_reader :domain, :client_id, :client_secret, :auth_type
 

--- a/lib/iron_bank/configuration.rb
+++ b/lib/iron_bank/configuration.rb
@@ -32,6 +32,9 @@ module IronBank
     # Open Tracing service name
     attr_accessor :open_tracing_service_name
 
+    # Faraday retry options
+    attr_writer :retry_options
+
     # Directory where the XML describe files are located.
     attr_reader :schema_directory
 
@@ -81,6 +84,10 @@ module IronBank
 
     def credentials?
       credentials.values.all?
+    end
+
+    def retry_options
+      @retry_options ||= IronBank::Client::DEFAULT_RETRY_OPTIONS
     end
   end
 end


### PR DESCRIPTION
### Description
Updates `IronBank::Client` to fetch its retry options from
`IronBank::Configuration`. This will allow clients to be able to customize how
their requests are retried.

### Risks
**Low**: Adds flexibility to how the retry options are sourced.
 * _Rollback:_ Revert commit