### PR TITLE
Log statements and updated backoff strategy for local records export

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iron_bank (2.2.0)
+    iron_bank (3.0.0)
       faraday (~> 0)
       faraday_middleware (~> 0)
       nokogiri (~> 1)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ IronBank.configure do |config|
   config.schema_directory  = 'directory-path' # schema drirectory path
 
   # Ironbank uses Faraday to send request to Zuora. Middlewares can be specified
-  # by adding the class name and class options to the `middlewares` 
+  # by adding the class name and class options to the `middlewares`
   # configuration.
   # Faraday middlewares, we can send in an array with cutomer middleware class
   # and options
@@ -133,6 +133,11 @@ https://github.com/zendesk/iron_bank.
 - `AutoPay` field on the `Invoice` object is not queryable using ZOQL despite
   the metadata showing `<selectable>true</selectable>`, hence it has been added
   to the `exclude_fields` method.
+- Exporting the local records through `IronBank::LocalRecords.export` can take a
+  long time (especially the `ProductRatePlanChargeTier` records). In case the
+  task fails because the export is still processing, you can manually download
+  the export from Zuora by going to **Reporting** -> **Data Sources** and
+  looking for the `ProductRatePlanChargeTier.csv` export.
 
 ## Copyright and license
 

--- a/lib/iron_bank/describe/object.rb
+++ b/lib/iron_bank/describe/object.rb
@@ -16,6 +16,7 @@ module IronBank
       end
 
       def self.from_connection(connection, name)
+        IronBank.logger.info "Describe (#{name})"
         xml = connection.get("v1/describe/#{name}").body
         new(Nokogiri::XML(xml))
       rescue TypeError

--- a/lib/iron_bank/local_records.rb
+++ b/lib/iron_bank/local_records.rb
@@ -34,10 +34,9 @@ module IronBank
     private
 
     BACKOFF = {
-      max:        3,
-      interval:   0.5,
-      randomness: 0.5,
-      factor:     4
+      max:        10,
+      interval:   1,
+      factor:     2
     }.freeze
     private_constant :BACKOFF
 
@@ -59,8 +58,9 @@ module IronBank
     end
 
     def export_query_info
-      "Waiting for export #{export.id} to complete " \
-        "(attempt #{query_attempts} of #{BACKOFF[:max]})"
+      "Waiting for export #{export.id} (#{resource}) to complete " \
+        "(attempt #{query_attempts} of #{BACKOFF[:max]}; #{backoff_time}s " \
+        "sleeping time)"
     end
 
     def completed?
@@ -85,11 +85,7 @@ module IronBank
     end
 
     def backoff_time
-      interval         = BACKOFF[:interval]
-      current_interval = interval * (BACKOFF[:factor]**query_attempts)
-      random_interval  = rand * BACKOFF[:randomness].to_f * interval
-
-      current_interval + random_interval
+      BACKOFF[:interval] * (BACKOFF[:factor]**query_attempts)
     end
   end
 end

--- a/lib/iron_bank/local_records.rb
+++ b/lib/iron_bank/local_records.rb
@@ -34,9 +34,9 @@ module IronBank
     private
 
     BACKOFF = {
-      max:        10,
-      interval:   1,
-      factor:     2
+      max:      10,
+      interval: 1,
+      factor:   2
     }.freeze
     private_constant :BACKOFF
 

--- a/lib/iron_bank/version.rb
+++ b/lib/iron_bank/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IronBank
-  VERSION     = "2.2.0"
+  VERSION     = "3.0.0"
   API_VERSION = "v1"
 end

--- a/spec/iron_bank/local_records_spec.rb
+++ b/spec/iron_bank/local_records_spec.rb
@@ -123,11 +123,11 @@ RSpec.describe IronBank::LocalRecords do
             to raise_error(IronBank::Error, "Export query attempts exceeded")
         end
 
-        it "attempts 4 queries" do
+        it "attempts 11 queries" do
           begin
             export
           rescue IronBank::Error
-            expect(export_instance).to have_received(:reload).exactly(4).times
+            expect(export_instance).to have_received(:reload).exactly(11).times
           end
         end
       end


### PR DESCRIPTION
### Description
- Updated `BACKOFF` constant to be simpler and have up to 10 attempts since `ProductRatePlanChargeTier` data source can prove very long to execute.
- Added known issue in `README.md` about it and how to recover from it.

### Risks
**Low.** Task is only used during setup time.