### PR TITLE
Fix IronBank::Invoice#body method

### DIFF
--- a/lib/iron_bank/resources/invoice.rb
+++ b/lib/iron_bank/resources/invoice.rb
@@ -30,7 +30,7 @@ module IronBank
       # We can only retrieve one invoice body at a time, hence Body is excluded
       # from the query fields, but is populated using the `find` class method
       def body
-        remote[:body] || reload[:body]
+        remote[:body] || reload.remote[:body]
       end
     end
   end

--- a/spec/iron_bank/resources/invoice_spec.rb
+++ b/spec/iron_bank/resources/invoice_spec.rb
@@ -45,7 +45,10 @@ RSpec.describe IronBank::Resources::Invoice do
       end
 
       it "reloads the invoice to fetch the body" do
-        expect(invoice).to receive(:reload).and_return(remote_with_body)
+        expect(invoice).
+          to receive(:reload).
+          and_return(described_class.new(remote_with_body))
+
         expect(invoice.body).to eq(invoice_body)
       end
     end


### PR DESCRIPTION
### Description
We changed how the `#reload` method works. It now returns the instance of the reloaded resource and not the updated `remote` hash. This introduced a bug with `IronBank::Invoice#body` which calls `#reload` if the `body` is missing (since it cannot be queried using ZOQL when there are more than one invoice in the response).

### Risks
**Low.** Fix a bug where invoice body is not returned.