### PR TITLE
Allow ProductRatePlanChargeTiers to be live-queried

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iron_bank (3.0.1)
+    iron_bank (3.0.2)
       faraday (~> 0)
       faraday_middleware (~> 0)
       nokogiri (~> 1)

--- a/lib/iron_bank/resources/product_rate_plan_charge_tier.rb
+++ b/lib/iron_bank/resources/product_rate_plan_charge_tier.rb
@@ -7,8 +7,9 @@ module IronBank
     #
     class ProductRatePlanChargeTier < Resource
       # These fields are declared as `<selectable>true</selectable>` but only
-      # ZOQL export. To let live queries go through when the local records are
-      # not exported, we only allow querying the non-discount tiers.
+      # for <context>export</export>, AKA ZOQL export. To let live queries go
+      # through when the local records are not exported, we only allow querying
+      # the non-discount tiers.
       def self.exclude_fields
         %w[
           Active

--- a/lib/iron_bank/resources/product_rate_plan_charge_tier.rb
+++ b/lib/iron_bank/resources/product_rate_plan_charge_tier.rb
@@ -7,7 +7,7 @@ module IronBank
     #
     class ProductRatePlanChargeTier < Resource
       # These fields are declared as `<selectable>true</selectable>` but only
-      # for <context>export</export>, AKA ZOQL export. To let live queries go
+      # for the `export` context (ie., via ZOQL export). To let live queries go
       # through when the local records are not exported, we only allow querying
       # the non-discount tiers.
       def self.exclude_fields

--- a/lib/iron_bank/resources/product_rate_plan_charge_tier.rb
+++ b/lib/iron_bank/resources/product_rate_plan_charge_tier.rb
@@ -6,6 +6,19 @@ module IronBank
     # charge.
     #
     class ProductRatePlanChargeTier < Resource
+      # These fields are declared as `<selectable>true</selectable>` but only
+      # ZOQL export. To let live queries go through when the local records are
+      # not exported, we only allow querying the non-discount tiers.
+      def self.exclude_fields
+        %w[
+          Active
+          IncludedUnits
+          OveragePrice
+          DiscountAmount
+          DiscountPercentage
+        ]
+      end
+
       with_schema
       with_local_records
       with_cache

--- a/lib/iron_bank/version.rb
+++ b/lib/iron_bank/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IronBank
-  VERSION     = "3.0.1"
+  VERSION     = "3.0.2"
   API_VERSION = "v1"
 end

--- a/spec/iron_bank/resources/product_rate_plan_charge_tier_spec.rb
+++ b/spec/iron_bank/resources/product_rate_plan_charge_tier_spec.rb
@@ -4,6 +4,21 @@ require "shared_examples/local"
 require "shared_examples/cacheable"
 
 RSpec.describe IronBank::Resources::ProductRatePlanChargeTier do
+  describe "::exclude_fields" do
+    let(:fields) do
+      %w[
+        Active
+        IncludedUnits
+        OveragePrice
+        DiscountAmount
+        DiscountPercentage
+      ]
+    end
+
+    subject { described_class.exclude_fields }
+    it { is_expected.to eq(fields) }
+  end
+
   let(:id) { "a-zuora-product-rate-plan-charge-tier-id" }
 
   it_behaves_like "a resource with local records"


### PR DESCRIPTION
### Description
Add the following `exclude_fields` to `ProductRatePlanChargeTier` to allow it to be live-queried (when the local records are not present).

```
Active
IncludedUnits
OveragePrice
DiscountAmount
DiscountPercentage
```

Caveat: this doesn't let us live-query Discount-Amount or Discount-Percentage tiers, but that's also a limitation of Zuora query. This should not be an issue though if the `LocalRecords` are properly exported using Zuora Export ZOQL (which doesn't have the same kind of limitation).


### Risks
**Low.** In their current state, `ProductRatePlanChargeTier` are not queryable.