### PR TITLE
Exclude CreditAmount and PaymentAmount from query fields

### DIFF
--- a/lib/iron_bank/resources/taxation_item.rb
+++ b/lib/iron_bank/resources/taxation_item.rb
@@ -7,7 +7,11 @@ module IronBank
     #
     class TaxationItem < Resource
       def self.exclude_fields
-        %w[Balance]
+        %w[
+          Balance
+          CreditAmount
+          PaymentAmount
+        ]
       end
       with_schema
 

--- a/spec/iron_bank/resources/taxation_item_spec.rb
+++ b/spec/iron_bank/resources/taxation_item_spec.rb
@@ -3,7 +3,11 @@
 RSpec.describe IronBank::Resources::TaxationItem do
   describe "::exclude_fields" do
     let(:fields) do
-      %w[Balance]
+      %w[
+        Balance
+        CreditAmount
+        PaymentAmount
+      ]
     end
 
     subject { described_class.exclude_fields }


### PR DESCRIPTION
### Description
TSIA

### Risks
**Low.** Fields are only available through a ZOQL export.