### PR TITLE
Add PaymentRun#create

### DIFF
--- a/lib/iron_bank.rb
+++ b/lib/iron_bank.rb
@@ -87,6 +87,7 @@ require "iron_bank/describe/tenant"
 require "iron_bank/object"
 require "iron_bank/schema"
 require "iron_bank/query_builder"
+require "iron_bank/payment_run"
 
 # Operations
 require "iron_bank/operation"

--- a/lib/iron_bank/payment_run.rb
+++ b/lib/iron_bank/payment_run.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module IronBank
+  # Create payment run
+  # https://www.zuora.com/developer/api-reference/#operation/POST_PaymentRun
+  #
+  class PaymentRun
+    ENDPOINT = "/v1/payment-runs"
+
+    def self.create(params)
+      payload = IronBank::Object.new(params).deep_camelize(type: :lower)
+      body    = IronBank.client.connection.post(ENDPOINT, payload).body
+      success = body.fetch('success', false)
+
+      raise ::IronBank::UnprocessableEntityError, body unless success
+
+      IronBank::Object.new(body).deep_underscore
+    end
+  end
+end

--- a/lib/iron_bank/payment_run.rb
+++ b/lib/iron_bank/payment_run.rb
@@ -10,7 +10,7 @@ module IronBank
     def self.create(params)
       payload = IronBank::Object.new(params).deep_camelize(type: :lower)
       body    = IronBank.client.connection.post(ENDPOINT, payload).body
-      success = body.fetch('success', false)
+      success = body.fetch("success", false)
 
       raise ::IronBank::UnprocessableEntityError, body unless success
 

--- a/spec/iron_bank/payment_run_spec.rb
+++ b/spec/iron_bank/payment_run_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe IronBank::PaymentRun do
+  describe ".create" do
+    subject(:create) { described_class.create(params) }
+
+    let(:params) do
+      {
+        account_id:  "zuora-account-id-1234",
+        target_date: "2019-05-07"
+      }
+    end
+
+    let(:payload) do
+      {
+        "accountId"  => params[:account_id],
+        "targetDate" => params[:target_date]
+      }
+    end
+
+    let(:conn)     { instance_double(Faraday::Connection) }
+    let(:client)   { instance_double(IronBank::Client, connection: conn) }
+    let(:response) { instance_double(Faraday::Response, body: body) }
+    let(:body)     { { success: success, fooBar: "baz" } }
+
+    before do
+      allow(IronBank).to receive(:client).and_return(client)
+
+      allow(conn).
+        to receive(:post).
+        with("/v1/payment-runs", payload).
+        and_return(response)
+    end
+
+    context "failure to submit a payment run" do
+      let(:success) { false }
+
+      specify do
+        expect { create }.to raise_error(IronBank::UnprocessableEntityError)
+      end
+    end
+
+    context "successfully submitted a payment run" do
+      let(:success) { true }
+
+      it { is_expected.to eq(success: true, foo_bar: "baz") }
+    end
+  end
+end

--- a/spec/iron_bank/payment_run_spec.rb
+++ b/spec/iron_bank/payment_run_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe IronBank::PaymentRun do
     let(:conn)     { instance_double(Faraday::Connection) }
     let(:client)   { instance_double(IronBank::Client, connection: conn) }
     let(:response) { instance_double(Faraday::Response, body: body) }
-    let(:body)     { { success: success, fooBar: "baz" } }
+    let(:body)     { { "success" => success, "fooBar" => "baz" } }
 
     before do
       allow(IronBank).to receive(:client).and_return(client)


### PR DESCRIPTION
### Description
- Add the ability to create a payment run for a given Zuora account.

Note that we are using the _commerce_ REST APIs, so the endpoint is `v1/payment-runs`, hence it's not an `Operation`, nor it is an `Action`. This is why we directly nested the class under `IronBank` module.

### References
- https://www.zuora.com/developer/api-reference/#operation/POST_PaymentRun

### Risks
**Low.** Brand new operation available through Iron Bank.