### PR TITLE
Add limit (optional) parameter to Query call

### DIFF
--- a/lib/iron_bank/actions/query.rb
+++ b/lib/iron_bank/actions/query.rb
@@ -20,11 +20,13 @@ module IronBank
       end
 
       def params
-        if limit.zero?
-          { queryString: zoql }
-        else
-          { queryString: zoql, conf: { batchSize: limit } }
-        end
+        return required_params if limit.zero?
+
+        required_params.merge(conf: { batchSize: limit })
+      end
+
+      def required_params
+        { queryString: zoql }
       end
     end
   end

--- a/lib/iron_bank/actions/query.rb
+++ b/lib/iron_bank/actions/query.rb
@@ -6,10 +6,25 @@ module IronBank
     # https://knowledgecenter.zuora.com/DC_Developers/K_Zuora_Object_Query_Language
     #
     class Query < Action
+      def self.call(zoql, limit: 0)
+        new(zoql, limit).call
+      end
+
       private
 
+      attr_reader :zoql, :limit
+
+      def initialize(zoql, limit)
+        @zoql  = zoql
+        @limit = limit
+      end
+
       def params
-        { 'queryString': args }
+        if limit.zero?
+          { queryString: zoql }
+        else
+          { queryString: zoql, conf: { batchSize: limit } }
+        end
       end
     end
   end

--- a/spec/iron_bank/actions/query_spec.rb
+++ b/spec/iron_bank/actions/query_spec.rb
@@ -3,9 +3,21 @@
 require "shared_examples/action"
 
 RSpec.describe IronBank::Actions::Query do
-  it_behaves_like "a Zuora action" do
-    let(:args)     { anything }
-    let(:endpoint) { "v1/action/query" }
-    let(:params)   { { 'queryString': args } }
+  context "only passing a ZOQL string" do
+    it_behaves_like "a Zuora action" do
+      let(:args)     { "select FieldName from ObjectName" }
+      let(:endpoint) { "v1/action/query" }
+      let(:params)   { { 'queryString': args } }
+    end
+  end
+
+  context "passing ZOQL and a limit" do
+    it_behaves_like "a Zuora action" do
+      let(:zoql)         { "select FieldName from ObjectName" }
+      let(:limit)        { 1 }
+      let(:endpoint)     { "v1/action/query" }
+      let(:params)       { { queryString: zoql, conf: { batchSize: limit } } }
+      let(:execute_call) { described_class.call(zoql, limit: limit) }
+    end
   end
 end

--- a/spec/shared_examples/action.rb
+++ b/spec/shared_examples/action.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "a Zuora action" do
-  let(:client)     { instance_double(IronBank::Client) }
-  let(:connection) { instance_double(Faraday::Connection) }
-  let(:response)   { instance_double(Faraday::Response, body: body) }
-  let(:body)       { [{}] }
+  let(:client)       { instance_double(IronBank::Client) }
+  let(:connection)   { instance_double(Faraday::Connection) }
+  let(:response)     { instance_double(Faraday::Response, body: body) }
+  let(:body)         { [{}] }
+  let(:execute_call) { described_class.call(args) }
 
   describe "::call" do
     before do
@@ -12,15 +13,13 @@ RSpec.shared_examples "a Zuora action" do
       allow(client).to receive(:connection).and_return(connection)
     end
 
-    subject(:call) { described_class.call(args) }
-
     it "sends a POST request to Zuora" do
       expect(connection).
         to receive(:post).
         with(endpoint, params).
         and_return(response)
 
-      call
+      execute_call
     end
   end
 end


### PR DESCRIPTION
### Description
The [`Query`](https://www.zuora.com/developer/api-reference/#operation/Action_POSTquery) action from Zuora accepts an optional `batchSize` parameter (nested in a `conf` object).

> Defines the batch size of the query result. The range is 1 - 2000 (inclusive). If a value higher than 2000 is submitted, only 2000 results are returned.

This changeset modifies the `IronBank::Query.call` method to accept an `limit` option.

```rb
IronBank::Query.call "select Id, Name from Product", limit: 1
# => POST /v1/action/query
# { queryString: "select Id, Name from Product", conf: { batchSize: 1 } }
```

**Existing calls are unchanged** as we are defaulting `limit` to `0` and not passing it to Zuora if `limit.zero?` is `TRUE`.

```rb
IronBank::Query.call "select Id, Name from Product"
# => POST /v1/action/query
# { queryString: "select Id, Name from Product" }
```

### Risks
**Low.** New optional parameter, doesn't affect existing calls.