### PR TITLE
[EDITED] Do not reference internal links in open source projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ cache: bundler
 
 language: ruby
 
+addons:
+  srcclr: true
+
 rvm:
   - 2.4.6
   - 2.5.5
@@ -18,6 +21,7 @@ before_install:
 
 env:
   global:
+    - SECURITYSCAN="srcclr"
     - ZUORA_CLIENT_ID=something
     - ZUORA_CLIENT_SECRET=secret
     - ZUORA_DOMAIN=rest.apisandbox.zuora.com


### PR DESCRIPTION
### Description
This change adds the configs for SourceClear into the .travis.yml file.

cc: :whale2: @zendesk/billing

### Tasks
 - [ ] Generate and set SRCCLR_API_TOKEN var for project.

### References
 - [Do not reference internal links in open source projects]

### Risks
**Low.** Travis configuration only.
