### PR TITLE
Bumps Nokogiri Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multipart-post (2.1.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.2.1)
@@ -131,4 +131,4 @@ DEPENDENCIES
   timecop (~> 0.9.0)
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
### Description
Bumps the `nokogiri` gem to address a CVE.

### References
* https://nvd.nist.gov/vuln/detail/CVE-2019-5477

### Risks
**Low**: Bumps a gem dependency.
 * _Rollback:_ Revert commit