### PR TITLE
Add a #first method for each queryable resource

### DIFF
--- a/lib/iron_bank/actions/query.rb
+++ b/lib/iron_bank/actions/query.rb
@@ -6,6 +6,11 @@ module IronBank
     # https://knowledgecenter.zuora.com/DC_Developers/K_Zuora_Object_Query_Language
     #
     class Query < Action
+      # Zuora's default is 2,000 records, but we simply use `0` here to not pass
+      # the parameter to Zuora APIs during the query call.
+      #
+      # See https://knowledgecenter.zuora.com/DC_Developers/BC_ZOQL#Limits
+      #
       DEFAULT_ZUORA_LIMIT = 0
 
       def self.call(zoql, limit: DEFAULT_ZUORA_LIMIT)

--- a/lib/iron_bank/actions/query.rb
+++ b/lib/iron_bank/actions/query.rb
@@ -6,7 +6,9 @@ module IronBank
     # https://knowledgecenter.zuora.com/DC_Developers/K_Zuora_Object_Query_Language
     #
     class Query < Action
-      def self.call(zoql, limit: 0)
+      DEFAULT_ZUORA_LIMIT = 0
+
+      def self.call(zoql, limit: DEFAULT_ZUORA_LIMIT)
         new(zoql, limit).call
       end
 

--- a/lib/iron_bank/cacheable.rb
+++ b/lib/iron_bank/cacheable.rb
@@ -32,7 +32,8 @@ module IronBank
         cache.fetch(id, force: force) { super(id) }
       end
 
-      def where(conditions, limit: 0)
+      def where(conditions,
+                limit: IronBank::Actions::Query::DEFAULT_ZUORA_LIMIT)
         # Conditions can be empty when called from #all, it does not make sense
         # to try to cache all records returned then.
         return super if conditions.empty?

--- a/lib/iron_bank/cacheable.rb
+++ b/lib/iron_bank/cacheable.rb
@@ -32,7 +32,7 @@ module IronBank
         cache.fetch(id, force: force) { super(id) }
       end
 
-      def where(conditions)
+      def where(conditions, limit: 0)
         # Conditions can be empty when called from #all, it does not make sense
         # to try to cache all records returned then.
         return super if conditions.empty?

--- a/lib/iron_bank/local.rb
+++ b/lib/iron_bank/local.rb
@@ -23,7 +23,7 @@ module IronBank
       store.any? ? store.values.first : super
     end
 
-    def where(conditions, limit: 0)
+    def where(conditions, limit: IronBank::Actions::Query::DEFAULT_ZUORA_LIMIT)
       records = store.values.select do |record|
         conditions.all? { |field, value| record.public_send(field) == value }
       end

--- a/lib/iron_bank/local.rb
+++ b/lib/iron_bank/local.rb
@@ -19,7 +19,11 @@ module IronBank
       store.any? ? store.values : super
     end
 
-    def where(conditions)
+    def first
+      store.any? ? store.values.first : super
+    end
+
+    def where(conditions, limit: 0)
       records = store.values.select do |record|
         conditions.all? { |field, value| record.public_send(field) == value }
       end

--- a/lib/iron_bank/queryable.rb
+++ b/lib/iron_bank/queryable.rb
@@ -40,7 +40,7 @@ module IronBank
       where({}, limit: 1).first
     end
 
-    def where(conditions, limit: 0)
+    def where(conditions, limit: IronBank::Actions::Query::DEFAULT_ZUORA_LIMIT)
       query_string = IronBank::QueryBuilder.zoql(
         object_name,
         query_fields,

--- a/lib/iron_bank/queryable.rb
+++ b/lib/iron_bank/queryable.rb
@@ -17,6 +17,9 @@ module IronBank
 
     # This methods leverages the fact that Zuora only returns 2,000 records at a
     # time, hance providing a default batch size
+    #
+    # See https://knowledgecenter.zuora.com/DC_Developers/BC_ZOQL#Limits
+    #
     def find_each
       return enum_for(:find_each) unless block_given?
 
@@ -41,14 +44,10 @@ module IronBank
     end
 
     def where(conditions, limit: IronBank::Actions::Query::DEFAULT_ZUORA_LIMIT)
-      query_string = IronBank::QueryBuilder.zoql(
-        object_name,
-        query_fields,
-        conditions
-      )
+      query_string = IronBank::QueryBuilder.
+                     zoql(object_name, query_fields, conditions)
 
-      # FIXME: need to use logger instance instead
-      # puts "query: #{query_string}"
+      IronBank.logger.info "query: #{query_string}"
 
       records = IronBank::Query.call(query_string, limit: limit)[:records]
       return [] unless records

--- a/lib/iron_bank/queryable.rb
+++ b/lib/iron_bank/queryable.rb
@@ -36,7 +36,11 @@ module IronBank
       where({})
     end
 
-    def where(conditions)
+    def first
+      where({}, limit: 1).first
+    end
+
+    def where(conditions, limit: 0)
       query_string = IronBank::QueryBuilder.zoql(
         object_name,
         query_fields,
@@ -46,7 +50,7 @@ module IronBank
       # FIXME: need to use logger instance instead
       # puts "query: #{query_string}"
 
-      records = IronBank::Query.call(query_string)[:records]
+      records = IronBank::Query.call(query_string, limit: limit)[:records]
       return [] unless records
 
       records.each.with_object([]) do |data, result|

--- a/spec/shared_examples/cacheable.rb
+++ b/spec/shared_examples/cacheable.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples "a cacheable resource" do
       subject(:where_without_cache) { described_class.where(conditions) }
 
       it "makes a live query" do
-        expect(IronBank::Resource).to receive(:where).with(conditions)
+        expect(IronBank::Resource).to receive(:where).with(conditions, limit: 0)
         where_without_cache
       end
     end

--- a/spec/shared_examples/local.rb
+++ b/spec/shared_examples/local.rb
@@ -126,6 +126,15 @@ RSpec.shared_examples "a resource with local records" do
       end
     end
 
+    describe "::first" do
+      subject(:first) { described_class.first }
+
+      it "makes a live query" do
+        expect(IronBank::Resource).to receive(:first)
+        first
+      end
+    end
+
     describe "::where" do
       let(:conditions) { { id: id } }
 

--- a/spec/shared_examples/local.rb
+++ b/spec/shared_examples/local.rb
@@ -132,7 +132,7 @@ RSpec.shared_examples "a resource with local records" do
       subject(:where) { described_class.where(conditions) }
 
       it "makes a live query" do
-        expect(IronBank::Resource).to receive(:where).with(conditions)
+        expect(IronBank::Resource).to receive(:where).with(conditions, limit: 0)
         where
       end
     end

--- a/spec/shared_examples/queryable.rb
+++ b/spec/shared_examples/queryable.rb
@@ -96,12 +96,28 @@ RSpec.shared_examples "a queryable resource" do
     end
   end
 
-  describe ":all" do
+  describe "::all" do
     subject(:all) { described_class.all }
 
     it "delegates to where without conditions" do
       expect(described_class).to receive(:where).with({})
+
       all
+    end
+  end
+
+  describe "::first" do
+    subject(:first) { described_class.first }
+
+    let(:result) { { foo: "bar" } }
+
+    it "delegates to where without conditions and returns the first result" do
+      expect(described_class).
+        to receive(:where).
+        with({}, limit: 1).
+        and_return([result])
+
+      expect(first).to eq(result)
     end
   end
 


### PR DESCRIPTION
### Description
Zuora let us specify a `limit` parameter when making a `Query`. By leveraging this, we can offer an "efficient" (well, as fast as Zuora response) way of querying the first record (usually, this is sorted by Zuora in `last_modified_at DESC` order).

There are many uses, but my preferred one is to quickly test a `ZOQL` query, which you can see in https://github.com/zendesk/iron_bank/pull/38

```rb
IronBank::Account.first
# => "select * from Account", limit: 1
```

### Risks
**Low.** Brand new class method, not used anywhere. Minor bump needed (add new feature).