### PR TITLE
Append excluded fields to the schema instead of stomping on it

### DIFF
--- a/lib/iron_bank/describe/excluded_fields.rb
+++ b/lib/iron_bank/describe/excluded_fields.rb
@@ -41,7 +41,7 @@ module IronBank
       def call
         remove_last_failure_fields until valid_query?
 
-        excluded_fields - separate_query_fields
+        excluded_fields - single_resource_query_fields
       end
 
       private
@@ -49,7 +49,7 @@ module IronBank
       attr_reader :object_name, :last_failed_fields
 
       def_delegators "IronBank.logger", :info
-      def_delegators :object, :separate_query_fields
+      def_delegators :object, :single_resource_query_fields
 
       def initialize(object_name)
         @object_name        = object_name

--- a/lib/iron_bank/metadata.rb
+++ b/lib/iron_bank/metadata.rb
@@ -12,6 +12,13 @@ module IronBank
       fields.fetch(object_name, [])
     end
 
+    # NOTE: For some resources, fields are queryable with some restrictions,
+    #       e.g. the `Invoice#body` can only be added to the list of fields if
+    #       there is only one invoice in the query response.
+    def separate_query_fields
+      []
+    end
+
     def fields
       return [] unless schema
 

--- a/lib/iron_bank/metadata.rb
+++ b/lib/iron_bank/metadata.rb
@@ -15,7 +15,7 @@ module IronBank
     # NOTE: For some resources, fields are queryable with some restrictions,
     #       e.g. the `Invoice#body` can only be added to the list of fields if
     #       there is only one invoice in the query response.
-    def separate_query_fields
+    def single_resource_query_fields
       []
     end
 

--- a/lib/iron_bank/resources/invoice.rb
+++ b/lib/iron_bank/resources/invoice.rb
@@ -8,7 +8,11 @@ module IronBank
     class Invoice < Resource
       # See the comment for the instance method `#body`
       def self.excluded_fields
-        super + %w[Body]
+        super + separate_query_fields
+      end
+
+      def self.separate_query_fields
+        %w[Body]
       end
 
       with_schema

--- a/lib/iron_bank/resources/invoice.rb
+++ b/lib/iron_bank/resources/invoice.rb
@@ -8,10 +8,10 @@ module IronBank
     class Invoice < Resource
       # See the comment for the instance method `#body`
       def self.excluded_fields
-        super + separate_query_fields
+        super + single_resource_query_fields
       end
 
-      def self.separate_query_fields
+      def self.single_resource_query_fields
         %w[Body]
       end
 

--- a/lib/iron_bank/resources/product_rate_plan.rb
+++ b/lib/iron_bank/resources/product_rate_plan.rb
@@ -9,10 +9,10 @@ module IronBank
       # NOTE: Zuora doesn't let us query for more than one product rate plan
       #       `ActiveCurrencies` at a time
       def self.excluded_fields
-        super + separate_query_fields
+        super + single_resource_query_fields
       end
 
-      def self.separate_query_fields
+      def self.single_resource_query_fields
         %w[ActiveCurrencies]
       end
 

--- a/lib/iron_bank/resources/product_rate_plan.rb
+++ b/lib/iron_bank/resources/product_rate_plan.rb
@@ -9,7 +9,11 @@ module IronBank
       # NOTE: Zuora doesn't let us query for more than one product rate plan
       #       `ActiveCurrencies` at a time
       def self.excluded_fields
-        super + %w[ActiveCurrencies]
+        super + separate_query_fields
+      end
+
+      def self.separate_query_fields
+        %w[ActiveCurrencies]
       end
 
       with_schema

--- a/lib/iron_bank/resources/rate_plan_charge.rb
+++ b/lib/iron_bank/resources/rate_plan_charge.rb
@@ -6,7 +6,11 @@ module IronBank
     #
     class RatePlanCharge < Resource
       def self.excluded_fields
-        super + %w[RolloverBalance]
+        super + separate_query_fields
+      end
+
+      def self.separate_query_fields
+        %w[RolloverBalance]
       end
 
       with_schema

--- a/lib/iron_bank/resources/rate_plan_charge.rb
+++ b/lib/iron_bank/resources/rate_plan_charge.rb
@@ -6,10 +6,10 @@ module IronBank
     #
     class RatePlanCharge < Resource
       def self.excluded_fields
-        super + separate_query_fields
+        super + single_resource_query_fields
       end
 
-      def self.separate_query_fields
+      def self.single_resource_query_fields
         %w[RolloverBalance]
       end
 

--- a/spec/shared_examples/metadata.rb
+++ b/spec/shared_examples/metadata.rb
@@ -9,6 +9,11 @@ RSpec.shared_examples "a resource with metadata" do
     it { is_expected.to be_an(Array) }
   end
 
+  describe "#separate_query_fields" do
+    subject { described_class.excluded_fields }
+    it { is_expected.to be_an(Array) }
+  end
+
   describe "#fields" do
     subject { described_class.fields }
 

--- a/spec/shared_examples/metadata.rb
+++ b/spec/shared_examples/metadata.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "a resource with metadata" do
     it { is_expected.to be_an(Array) }
   end
 
-  describe "#separate_query_fields" do
+  describe "#single_resource_query_fields" do
     subject { described_class.excluded_fields }
     it { is_expected.to be_an(Array) }
   end


### PR DESCRIPTION
### Description
Fix an issue when running `bundle exec rake excluded_fields` where the `IronBank::Schema#excluded_fields` would not include fields from the current configuration file, effectively stomping on them.

### How to reproduce

Execute this command twice:

```
bundle exec rake excluded_fields
```

And on the second run, the fields are effectively removed from the `excluded_fields.yml` file, which is not the expected behavior.

### Expected behavior

Running the rake task should be idempotent.

### Risks
**Low.** Bug fix for `rake` task.