### PR TITLE
IronBank::Schema#reset should completely refresh each resource

### DIFF
--- a/lib/iron_bank/metadata.rb
+++ b/lib/iron_bank/metadata.rb
@@ -35,6 +35,14 @@ module IronBank
       @schema ||= IronBank::Schema.for(object_name)
     end
 
+    def reset
+      %i[@fields @query_fields @schema].each do |var|
+        remove_instance_variable(var) if instance_variable_defined?(var)
+      end
+
+      with_schema
+    end
+
     def with_schema
       fields.each do |field|
         field_name = IronBank::Utils.underscore(field).to_sym

--- a/lib/iron_bank/schema.rb
+++ b/lib/iron_bank/schema.rb
@@ -31,7 +31,11 @@ module IronBank
     end
 
     def self.reset
-      @import = nil
+      remove_instance_variable(:@import)
+
+      IronBank::Resources.constants.each do |resource|
+        IronBank::Resources.const_get(resource).reset
+      end
     end
 
     def self.excluded_fields

--- a/spec/iron_bank/configuration_spec.rb
+++ b/spec/iron_bank/configuration_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe IronBank::Configuration do
       set_schema
     end
 
-    it "calls #with_schema on each resource, except modules" do
+    it "resets each resource, except modules" do
       IronBank::Resources.constants.each do |resource|
         klass = IronBank::Resources.const_get(resource)
         next unless klass.is_a?(Class)
 
-        expect(klass).to receive(:with_schema)
+        expect(klass).to receive(:with_schema).twice
       end
 
       set_schema

--- a/spec/iron_bank/schema_spec.rb
+++ b/spec/iron_bank/schema_spec.rb
@@ -47,15 +47,34 @@ RSpec.describe IronBank::Schema do
   describe "::reset" do
     before do
       IronBank::Schema.instance_variable_set :@import, anything
+
+      allow(IronBank::Schema).
+        to receive(:remove_instance_variable).
+        with(:@import)
+
+      IronBank::Resources.constants.each do |resource|
+        object = IronBank::Resources.const_get(resource)
+
+        allow(object).to receive(:reset)
+      end
     end
 
     subject(:reset) { described_class.reset }
 
-    it "nil the @import instance variable" do
-      expect { reset }.
-        to change { IronBank::Schema.instance_variable_get :@import }.
-        from(anything).
-        to(nil)
+    it "removes the @import instance variable" do
+      reset
+
+      expect(IronBank::Schema).to have_received(:remove_instance_variable)
+    end
+
+    it "calls #reset on each resource" do
+      reset
+
+      IronBank::Resources.constants.each do |resource|
+        object = IronBank::Resources.const_get(resource)
+
+        expect(object).to have_received(:reset)
+      end
     end
   end
 

--- a/spec/shared_examples/metadata.rb
+++ b/spec/shared_examples/metadata.rb
@@ -103,4 +103,26 @@ RSpec.shared_examples "a resource with metadata" do
       end
     end
   end
+
+  describe "#reset" do
+    subject(:reset) { described_class.reset }
+
+    before { allow(described_class).to receive(:with_schema) }
+
+    it "removes all instance variables" do
+      reset
+
+      vars = %i[@fields @query_fields @schema].map do |var|
+        described_class.instance_variable_defined?(var)
+      end
+
+      expect(vars).to all(be false)
+    end
+
+    it "calls #with_schema" do
+      reset
+
+      expect(described_class).to have_received(:with_schema)
+    end
+  end
 end


### PR DESCRIPTION
### Description
Modifies the `IronBank::Schema#reset` method to re-read the XML files (from the exported schema) and handle any new fields added to it without having to reload the entire class.

### What does it fix?
When running `IronBank::Schema.export`, new fields could be present in the exported files. But these fields are not available as an instance method and/or query fields for each `IronBank::Resources` since the `#with_schema` has not been called again for these class.

### How to reproduce
1. Edit your `Account.xml` (or any other class) to remove a `<field>...</field>` XML node
2. Open an IronBank console by running `bin/console`
3. Verify that your `IronBank::Account` no longer define a method associated with that field

```rb
IronBank::Account.instance_methods.include?(:my_field__c)
# => false
```

4. **Without quitting** the `bin/console`, edit and save the `Account.xml` file to re-include your field
5. Call `IronBank::Schema.reset`
6. Verify your field is not included for the `IronBank::Account` resource

```rb
IronBank::Account.instance_methods.include?(:my_field__c)
# => true
```

### Risks
**Low.** `IronBank::Schema.reset` should be reserved for management operations, e.g. exporting the schema, and not be called at runtime.