### PR TITLE
Sorts the Excluded Fields for Resources

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ task :excluded_fields, [:filename] do |_t, args|
   setup_iron_bank
 
   destination = args[:filename] || IronBank.configuration.excluded_fields_file
-  fields      = IronBank::Schema.excluded_fields
+  fields      = IronBank::Schema.excluded_fields.sort.to_h
 
   File.open(destination, "w") { |file| file.write(Psych.dump(fields)) }
 end

--- a/lib/iron_bank/describe/excluded_fields.rb
+++ b/lib/iron_bank/describe/excluded_fields.rb
@@ -41,10 +41,12 @@ module IronBank
       def call
         remove_last_failure_fields until valid_query?
 
-        excluded_fields - single_resource_query_fields
+        (excluded_fields - single_resource_query_fields).sort
       end
 
       private
+
+      INVALID_OBJECT_ID = "InvalidObjectId"
 
       attr_reader :object_name, :last_failed_fields
 
@@ -78,9 +80,9 @@ module IronBank
       end
 
       def valid_query?
-        # Querying using the ID (indexed field) should return an empty
-        # collectio fast when it's successful
-        object.where(id: "XYZ")
+        # Querying using the ID (which is an indexed field) should return an
+        # empty collection very quickly when successful
+        object.where(id: INVALID_OBJECT_ID)
 
         info "Successful query for #{object_name}"
 

--- a/spec/iron_bank/describe/excluded_fields_spec.rb
+++ b/spec/iron_bank/describe/excluded_fields_spec.rb
@@ -1,62 +1,77 @@
 # frozen_string_literal: true
 
 RSpec.describe IronBank::Describe::ExcludedFields do
+  let(:object)     { IronBank::Resources.const_get(object_name) }
+  let(:invalid_id) { described_class::INVALID_OBJECT_ID }
+
   subject(:call) { described_class.call(object_name: object_name) }
 
-  describe "object without excluded fields" do
+  describe "when the object does not have any unqueryable fields" do
     let(:object_name) { "Product" }
 
     before do
-      allow(Object.const_get("IronBank::Resources::#{object_name}")).
-        to receive(:where).with(id: "XYZ") # Successful query
+      allow(object).to receive(:where).with(id: invalid_id) # Successful query
     end
 
-    it { is_expected.to eq([]) }
+    it "returns an empty array" do
+      expect(call).to eq([])
+    end
   end
 
-  describe "object with excluded fields" do
-    let(:object_name)   { "Invoice" }
-    let(:error_message) { "invalid field for query: invoice.foobar" }
-    let(:query_fields)  { %w[FooBar ValidField] }
-
-    let(:object) do
-      Object.const_get("IronBank::Resources::#{object_name}")
-    end
+  describe "when the object does have unqueryable fields" do
+    let(:object_name)    { "Invoice" }
+    let(:error_message1) { "invalid field for query: invoice.invalidfield1" }
+    let(:error_message2) { "invalid field for query: invoice.invalidfield2" }
+    let(:query_fields)   { %w[InvalidField2 InvalidField1 ValidField] }
+    let(:sorted_fields)  { call.sort }
 
     before do
+      allow(object).to receive(:query_fields).and_return(query_fields)
+
       num_query = 0
 
-      # Querying `Object#first`:
-      #   - for the first time raises an exception
-      #   - following calls are successful
-      allow(object).to receive(:where).with(id: "XYZ") do
+      # Querying `Object#where(id: invalid_id)`:
+      #   - The first time ("InvalidField2") raises an exception
+      #   - The second time ("InvalidField1") raises an exception
+      #   - All following calls are successful
+      allow(object).to receive(:where).with(id: invalid_id) do
         num_query += 1
-        raise IronBank::InternalServerError, error_message if num_query == 1
-      end
 
-      allow(object).to receive(:query_fields).and_return(query_fields)
+        # NOTE: This ordering is dictated by the order of `query_fields`
+        case num_query
+        when 1 then raise IronBank::InternalServerError, error_message2
+        when 2 then raise IronBank::InternalServerError, error_message1
+        else        anything
+        end
+      end
     end
 
-    it { is_expected.to eq(["FooBar"]) }
-
-    it "makes two queries" do
+    it "makes three queries" do
       call
 
-      expect(object).to have_received(:where).twice
+      expect(object).to have_received(:where).exactly(3).times
+    end
+
+    it "returns the unqueryable fields" do
+      expect(call).to contain_exactly("InvalidField1", "InvalidField2")
+    end
+
+    it "returns a sorted array of unqueryable fields" do
+      expect(call.sort).to eq(call)
     end
   end
 
-  describe "cannot parse error message" do
+  describe "when the query results in a `InternalServerError` error" do
     let(:object_name) { "Account" }
 
     before do
-      allow(Object.const_get("IronBank::Resources::#{object_name}")).
+      allow(object).
         to receive(:where).
-        with(id: "XYZ").
+        with(id: invalid_id).
         and_raise(IronBank::InternalServerError)
     end
 
-    specify do
+    it "raises a `RuntimeError` error" do
       expect { call }.to raise_error(RuntimeError, /Could not parse error/)
     end
   end


### PR DESCRIPTION
### Description
Updates `IronBank::Describe::ExcludedFields` & the `:excluded_fields` rake task
such that the excluded fields are sorted when saved to a file.

**EDIT**
It allows us to have better `git diff` since this file is (generally) expected to be versioned.

### Risks
**Low**: Updates the sorting of an exported file.
 * _Rollback:_ Revert commit