### PR TITLE
Improve spec coverage (100%)

### DIFF
--- a/spec/iron_bank/authentications/cookie_spec.rb
+++ b/spec/iron_bank/authentications/cookie_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "timecop"
+require "shared_examples/faraday_connection"
 
 RSpec.describe IronBank::Authentications::Cookie do
   let(:initial_session) do
@@ -58,15 +59,10 @@ RSpec.describe IronBank::Authentications::Cookie do
   subject { described_class.call(credentials) }
 
   before do
-    allow(Faraday).to receive(:new).and_yield(connection).and_return(connection)
+    allow(Faraday).to receive(:new).and_return(connection)
 
-    # Faraday::Connection configuration
-    allow(connection).to receive(:request)
-    allow(connection).to receive(:response)
-    allow(connection).to receive(:adapter)
-
-    # Faraday::Connection POST request
-    allow(connection).to receive(:post).
+    allow(connection).
+      to receive(:post).
       and_return(first_response, second_response)
   end
 
@@ -138,54 +134,5 @@ RSpec.describe IronBank::Authentications::Cookie do
     end
   end
 
-  # FIXME: Extract in a shared example since it's also used in token_spec.rb
-  describe "#connection" do
-    subject(:faraday_connection) do
-      described_class.new(credentials).send(:connection)
-    end
-
-    it "uses URL encoded format for the request" do
-      faraday_connection
-      expect(connection).to have_received(:request).with(:url_encoded)
-    end
-
-    it "set the response to be parsed using JSON" do
-      faraday_connection
-      expect(connection).to have_received(:request).with(:url_encoded)
-    end
-
-    it "uses the default Faraday adapter" do
-      faraday_connection
-
-      expect(connection).
-        to have_received(:adapter).
-        with(Faraday.default_adapter)
-    end
-
-    describe "IronBank configurable middlewares" do
-      before do
-        allow(connection).to receive(:use)
-      end
-
-      context "no middleware configured" do
-        it "does not configure the Faraday::Connection to use any" do
-          faraday_connection
-
-          expect(connection).to_not have_received(:use)
-        end
-      end
-
-      context "with a middleware configured" do
-        before { IronBank.configuration.middlewares = %i[Foo Bar] }
-        after  { IronBank.configuration.middlewares = [] }
-
-        it "configures the Faraday::Connection to use the middlewares" do
-          faraday_connection
-
-          expect(connection).to have_received(:use).with(:Foo, nil)
-          expect(connection).to have_received(:use).with(:Bar, nil)
-        end
-      end
-    end
-  end
+  include_examples "Faraday::Connection configuration block"
 end

--- a/spec/iron_bank/authentications/cookie_spec.rb
+++ b/spec/iron_bank/authentications/cookie_spec.rb
@@ -58,7 +58,14 @@ RSpec.describe IronBank::Authentications::Cookie do
   subject { described_class.call(credentials) }
 
   before do
-    allow(Faraday).to receive(:new).and_return(connection)
+    allow(Faraday).to receive(:new).and_yield(connection).and_return(connection)
+
+    # Faraday::Connection configuration
+    allow(connection).to receive(:request)
+    allow(connection).to receive(:response)
+    allow(connection).to receive(:adapter)
+
+    # Faraday::Connection POST request
     allow(connection).to receive(:post).
       and_return(first_response, second_response)
   end
@@ -127,6 +134,57 @@ RSpec.describe IronBank::Authentications::Cookie do
 
       it "returns true" do
         expect(expired.expired?).to be_truthy
+      end
+    end
+  end
+
+  # FIXME: Extract in a shared example since it's also used in token_spec.rb
+  describe "#connection" do
+    subject(:faraday_connection) do
+      described_class.new(credentials).send(:connection)
+    end
+
+    it "uses URL encoded format for the request" do
+      faraday_connection
+      expect(connection).to have_received(:request).with(:url_encoded)
+    end
+
+    it "set the response to be parsed using JSON" do
+      faraday_connection
+      expect(connection).to have_received(:request).with(:url_encoded)
+    end
+
+    it "uses the default Faraday adapter" do
+      faraday_connection
+
+      expect(connection).
+        to have_received(:adapter).
+        with(Faraday.default_adapter)
+    end
+
+    describe "IronBank configurable middlewares" do
+      before do
+        allow(connection).to receive(:use)
+      end
+
+      context "no middleware configured" do
+        it "does not configure the Faraday::Connection to use any" do
+          faraday_connection
+
+          expect(connection).to_not have_received(:use)
+        end
+      end
+
+      context "with a middleware configured" do
+        before { IronBank.configuration.middlewares = %i[Foo Bar] }
+        after  { IronBank.configuration.middlewares = [] }
+
+        it "configures the Faraday::Connection to use the middlewares" do
+          faraday_connection
+
+          expect(connection).to have_received(:use).with(:Foo, nil)
+          expect(connection).to have_received(:use).with(:Bar, nil)
+        end
       end
     end
   end

--- a/spec/iron_bank/authentications/token_spec.rb
+++ b/spec/iron_bank/authentications/token_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "timecop"
+require "shared_examples/faraday_connection"
 
 RSpec.describe IronBank::Authentications::Token do
   let(:initial_token) do
@@ -61,15 +62,10 @@ RSpec.describe IronBank::Authentications::Token do
   subject { described_class.call(credentials) }
 
   before do
-    allow(Faraday).to receive(:new).and_yield(connection).and_return(connection)
+    allow(Faraday).to receive(:new).and_return(connection)
 
-    # Faraday::Connection configuration
-    allow(connection).to receive(:request)
-    allow(connection).to receive(:response)
-    allow(connection).to receive(:adapter)
-
-    # Faraday::Connection POST request
-    allow(connection).to receive(:post).
+    allow(connection).
+      to receive(:post).
       and_return(first_response, second_response)
   end
 
@@ -151,56 +147,7 @@ RSpec.describe IronBank::Authentications::Token do
         expect(expired.expired?).to be_truthy
       end
     end
-
-    # FIXME: Extract in a shared example since it's also used in cookie_spec.rb
-    describe "#connection" do
-      subject(:faraday_connection) do
-        described_class.new(credentials).send(:connection)
-      end
-
-      it "uses URL encoded format for the request" do
-        faraday_connection
-        expect(connection).to have_received(:request).with(:url_encoded)
-      end
-
-      it "set the response to be parsed using JSON" do
-        faraday_connection
-        expect(connection).to have_received(:request).with(:url_encoded)
-      end
-
-      it "uses the default Faraday adapter" do
-        faraday_connection
-
-        expect(connection).
-          to have_received(:adapter).
-          with(Faraday.default_adapter)
-      end
-
-      describe "IronBank configurable middlewares" do
-        before do
-          allow(connection).to receive(:use)
-        end
-
-        context "no middleware configured" do
-          it "does not configure the Faraday::Connection to use any" do
-            faraday_connection
-
-            expect(connection).to_not have_received(:use)
-          end
-        end
-
-        context "with a middleware configured" do
-          before { IronBank.configuration.middlewares = %i[Foo Bar] }
-          after  { IronBank.configuration.middlewares = [] }
-
-          it "configures the Faraday::Connection to use the middlewares" do
-            faraday_connection
-
-            expect(connection).to have_received(:use).with(:Foo, nil)
-            expect(connection).to have_received(:use).with(:Bar, nil)
-          end
-        end
-      end
-    end
   end
+
+  include_examples "Faraday::Connection configuration block"
 end

--- a/spec/iron_bank/authentications/token_spec.rb
+++ b/spec/iron_bank/authentications/token_spec.rb
@@ -61,7 +61,14 @@ RSpec.describe IronBank::Authentications::Token do
   subject { described_class.call(credentials) }
 
   before do
-    allow(Faraday).to receive(:new).and_return(connection)
+    allow(Faraday).to receive(:new).and_yield(connection).and_return(connection)
+
+    # Faraday::Connection configuration
+    allow(connection).to receive(:request)
+    allow(connection).to receive(:response)
+    allow(connection).to receive(:adapter)
+
+    # Faraday::Connection POST request
     allow(connection).to receive(:post).
       and_return(first_response, second_response)
   end
@@ -142,6 +149,57 @@ RSpec.describe IronBank::Authentications::Token do
 
       it "returns true" do
         expect(expired.expired?).to be_truthy
+      end
+    end
+
+    # FIXME: Extract in a shared example since it's also used in cookie_spec.rb
+    describe "#connection" do
+      subject(:faraday_connection) do
+        described_class.new(credentials).send(:connection)
+      end
+
+      it "uses URL encoded format for the request" do
+        faraday_connection
+        expect(connection).to have_received(:request).with(:url_encoded)
+      end
+
+      it "set the response to be parsed using JSON" do
+        faraday_connection
+        expect(connection).to have_received(:request).with(:url_encoded)
+      end
+
+      it "uses the default Faraday adapter" do
+        faraday_connection
+
+        expect(connection).
+          to have_received(:adapter).
+          with(Faraday.default_adapter)
+      end
+
+      describe "IronBank configurable middlewares" do
+        before do
+          allow(connection).to receive(:use)
+        end
+
+        context "no middleware configured" do
+          it "does not configure the Faraday::Connection to use any" do
+            faraday_connection
+
+            expect(connection).to_not have_received(:use)
+          end
+        end
+
+        context "with a middleware configured" do
+          before { IronBank.configuration.middlewares = %i[Foo Bar] }
+          after  { IronBank.configuration.middlewares = [] }
+
+          it "configures the Faraday::Connection to use the middlewares" do
+            faraday_connection
+
+            expect(connection).to have_received(:use).with(:Foo, nil)
+            expect(connection).to have_received(:use).with(:Bar, nil)
+          end
+        end
       end
     end
   end

--- a/spec/iron_bank/client_spec.rb
+++ b/spec/iron_bank/client_spec.rb
@@ -141,4 +141,37 @@ RSpec.describe IronBank::Client do
       expect(IronBank::Describe::Object).to have_received(:from_connection)
     end
   end
+
+  describe "DEFAULT_RETRY_OPTIONS" do
+    describe "retry_if" do
+      subject do
+        described_class::DEFAULT_RETRY_OPTIONS[:retry_if].
+          call(anything, exception)
+      end
+
+      context "IronBank::LockCompetitionError" do
+        let(:exception) { IronBank::LockCompetitionError.new }
+
+        it { is_expected.to be true }
+      end
+
+      context "IronBank::TemporaryError" do
+        let(:exception) { IronBank::TemporaryError.new }
+
+        it { is_expected.to be true }
+      end
+
+      context "IronBank::UnauthorizedError" do
+        let(:exception) { IronBank::UnauthorizedError.new }
+
+        it { is_expected.to be true }
+      end
+
+      context "not retriable" do
+        let(:exception) { StandardError.new }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
 end

--- a/spec/iron_bank/client_spec.rb
+++ b/spec/iron_bank/client_spec.rb
@@ -144,30 +144,29 @@ RSpec.describe IronBank::Client do
 
   describe "DEFAULT_RETRY_OPTIONS" do
     describe "retry_if" do
-      subject do
-        described_class::DEFAULT_RETRY_OPTIONS[:retry_if].
-          call(anything, exception)
-      end
+      let(:prok) { described_class::DEFAULT_RETRY_OPTIONS[:retry_if] }
 
-      context "IronBank::LockCompetitionError" do
+      subject { prok.call(anything, exception) }
+
+      context "for a IronBank::LockCompetitionError" do
         let(:exception) { IronBank::LockCompetitionError.new }
 
         it { is_expected.to be true }
       end
 
-      context "IronBank::TemporaryError" do
+      context "for a IronBank::TemporaryError" do
         let(:exception) { IronBank::TemporaryError.new }
 
         it { is_expected.to be true }
       end
 
-      context "IronBank::UnauthorizedError" do
+      context "for a IronBank::UnauthorizedError" do
         let(:exception) { IronBank::UnauthorizedError.new }
 
         it { is_expected.to be true }
       end
 
-      context "not retriable" do
+      context "for a non-retriable error" do
         let(:exception) { StandardError.new }
 
         it { is_expected.to be false }

--- a/spec/shared_examples/faraday_connection.rb
+++ b/spec/shared_examples/faraday_connection.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "Faraday::Connection configuration block" do
+  before do
+    allow(Faraday).to receive(:new).and_yield(connection).and_return(connection)
+
+    # Faraday::Connection configuration
+    allow(connection).to receive(:request)
+    allow(connection).to receive(:response)
+    allow(connection).to receive(:adapter)
+  end
+
+  subject(:faraday_connection) do
+    described_class.new(credentials).send(:connection)
+  end
+
+  it "uses URL encoded format for the request" do
+    faraday_connection
+    expect(connection).to have_received(:request).with(:url_encoded)
+  end
+
+  it "set the response to be parsed using JSON" do
+    faraday_connection
+    expect(connection).to have_received(:request).with(:url_encoded)
+  end
+
+  it "uses the default Faraday adapter" do
+    faraday_connection
+
+    expect(connection).
+      to have_received(:adapter).
+      with(Faraday.default_adapter)
+  end
+
+  describe "IronBank configurable middlewares" do
+    before do
+      allow(connection).to receive(:use)
+    end
+
+    context "no middleware configured" do
+      it "does not configure the Faraday::Connection to use any" do
+        faraday_connection
+
+        expect(connection).to_not have_received(:use)
+      end
+    end
+
+    context "with a middleware configured" do
+      before { IronBank.configuration.middlewares = %i[Foo Bar] }
+      after  { IronBank.configuration.middlewares = [] }
+
+      it "configures the Faraday::Connection to use the middlewares" do
+        faraday_connection
+
+        expect(connection).to have_received(:use).with(:Foo, nil)
+        expect(connection).to have_received(:use).with(:Bar, nil)
+      end
+    end
+  end
+end

--- a/spec/shared_examples/faraday_connection.rb
+++ b/spec/shared_examples/faraday_connection.rb
@@ -33,9 +33,7 @@ RSpec.shared_examples "Faraday::Connection configuration block" do
   end
 
   describe "IronBank configurable middlewares" do
-    before do
-      allow(connection).to receive(:use)
-    end
+    before { allow(connection).to receive(:use) }
 
     context "no middleware configured" do
       it "does not configure the Faraday::Connection to use any" do


### PR DESCRIPTION
### Description
- Add coverage for `Faraday::Connection` configuration block
- Add coverage for default `retry_if` proc

### Results
![Screenshot_2019-09-18 Code coverage for Iron bank](https://user-images.githubusercontent.com/2132303/65176217-2e6d8100-da09-11e9-9ea7-0b9a59108c31.png)

_Drop mic_

### Risks
**Low.** Improve spec coverage, no change to existing code.
