### PR TITLE
Add IronBank::User

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ ZUORA_AUTH_TYPE=token
 ZUORA_DOMAIN=rest.apisandbox.zuora.com
 ZUORA_TENANT_ID=00000
 ZUORA_EXCLUDED_FIELDS_FILE=excluded_fields.yml
+ZUORA_USERS_FILE=users.csv

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # do not version specific excluded fields
 excluded_fields.yml
+
+# do not version users (but let the fixtures be versioned)
+users.csv

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@
 # do not version specific excluded fields
 excluded_fields.yml
 
-# do not version users (but let the fixtures be versioned)
+# do not version exported users
 users.csv

--- a/.reek.yml
+++ b/.reek.yml
@@ -18,7 +18,7 @@ detectors:
       - IronBank::Configuration#logger
       - IronBank::Configuration#middlewares
       - IronBank::Configuration#schema_directory
-      - IronBank::Configuration#zuora_users_file
+      - IronBank::Configuration#users_file
 
   BooleanParameter:
     exclude:

--- a/.reek.yml
+++ b/.reek.yml
@@ -18,6 +18,7 @@ detectors:
       - IronBank::Configuration#logger
       - IronBank::Configuration#middlewares
       - IronBank::Configuration#schema_directory
+      - IronBank::Configuration#zuora_users_file
 
   BooleanParameter:
     exclude:

--- a/bin/console
+++ b/bin/console
@@ -12,6 +12,7 @@ IronBank.configure do |config|
   config.auth_type            = ENV.fetch("ZUORA_AUTH_TYPE", "token")
   config.domain               = ENV["ZUORA_DOMAIN"]
   config.excluded_fields_file = ENV["ZUORA_EXCLUDED_FIELDS_FILE"]
+  config.zuora_users_file     = ENV["ZUORA_USERS_FILE"]
 end
 
 Pry.start

--- a/bin/console
+++ b/bin/console
@@ -12,7 +12,7 @@ IronBank.configure do |config|
   config.auth_type            = ENV.fetch("ZUORA_AUTH_TYPE", "token")
   config.domain               = ENV["ZUORA_DOMAIN"]
   config.excluded_fields_file = ENV["ZUORA_EXCLUDED_FIELDS_FILE"]
-  config.zuora_users_file     = ENV["ZUORA_USERS_FILE"]
+  config.users_file           = ENV["ZUORA_USERS_FILE"]
 end
 
 Pry.start

--- a/lib/iron_bank.rb
+++ b/lib/iron_bank.rb
@@ -88,6 +88,7 @@ require "iron_bank/object"
 require "iron_bank/schema"
 require "iron_bank/query_builder"
 require "iron_bank/payment_run"
+require "iron_bank/user"
 
 # Operations
 require "iron_bank/operation"

--- a/lib/iron_bank/configuration.rb
+++ b/lib/iron_bank/configuration.rb
@@ -34,6 +34,9 @@ module IronBank
     # Directory where the local records are exported.
     attr_reader :export_directory
 
+    # File path for Zuora users export
+    attr_accessor :zuora_users_file
+
     def initialize
       @schema_directory = "./config/schema"
       @export_directory = "./config/export"

--- a/lib/iron_bank/configuration.rb
+++ b/lib/iron_bank/configuration.rb
@@ -35,7 +35,7 @@ module IronBank
     attr_reader :export_directory
 
     # File path for Zuora users export
-    attr_accessor :zuora_users_file
+    attr_accessor :users_file
 
     def initialize
       @schema_directory = "./config/schema"

--- a/lib/iron_bank/user.rb
+++ b/lib/iron_bank/user.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module IronBank
+  # A Zuora user, only available if the user data has been exported and provided
+  # to IronBank through the `zuora_users_file` configuration option.
+  #
+  # Cf. https://knowledgecenter.zuora.com/CF_Users_and_Administrators/A_Administrator_Settings/Manage_Users#Export_User_Data_to_a_CSV_File
+  #
+  class User
+    extend IronBank::Local
+
+    class << self
+      def store
+        zuora_users_file = IronBank.configuration.zuora_users_file
+        return {} unless zuora_users_file
+
+        @store ||= begin
+          if File.exist?(zuora_users_file)
+            load_records
+          else
+            IronBank.logger.warn "File does not exist: #{zuora_users_file}"
+            {}
+          end
+        end
+      end
+
+      def load_records
+        file = IronBank.configuration.zuora_users_file
+
+        CSV.foreach(file, headers: true).with_object({}) do |row, store|
+          store[row["User ID"]] = new(row.to_h.compact)
+        end
+      end
+
+      def all
+        store.values
+      end
+
+      def find(user_id)
+        store[user_id]
+      end
+    end
+
+    US_DATE_FORMAT = "%m/%d/%Y"
+
+    FIELDS = [
+      "User ID",
+      "User Name",
+      "First Name",
+      "Last Name",
+      "Status",
+      "Work Email",
+      "Created On",
+      "Zuora Billing Role",
+      "Zuora Payment Role",
+      "Zuora Commerce Role",
+      "Zuora Platform Role",
+      "Zuora Finance Role",
+      "Zuora Reporting Role",
+      "Zuora Insights Role",
+      "Last Login"
+    ].freeze
+
+    FIELDS.each do |field|
+      method_name = IronBank::Utils.underscore(field.tr(" ", ""))
+
+      define_method(method_name) do
+        attributes[field]
+      end
+    end
+
+    attr_reader :attributes
+
+    alias id user_id
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def inspect
+      ruby_id = "#{self.class.name}:0x#{(object_id << 1).to_s(16)} id=\"#{id}\""
+
+      "#<#{ruby_id} user_name=\"#{user_name}\">"
+    end
+
+    def last_login
+      @last_login ||= Date.strptime(attributes["Last Login"], US_DATE_FORMAT)
+    end
+
+    def created_on
+      @created_on ||= Date.strptime(attributes["Created On"], US_DATE_FORMAT)
+    end
+  end
+end

--- a/lib/iron_bank/user.rb
+++ b/lib/iron_bank/user.rb
@@ -2,7 +2,7 @@
 
 module IronBank
   # A Zuora user, only available if the user data has been exported and provided
-  # to IronBank through the `zuora_users_file` configuration option.
+  # to IronBank through the `users_file` configuration option.
   #
   # Cf. https://knowledgecenter.zuora.com/CF_Users_and_Administrators/A_Administrator_Settings/Manage_Users#Export_User_Data_to_a_CSV_File
   #
@@ -10,27 +10,24 @@ module IronBank
     extend IronBank::Local
     extend SingleForwardable
 
-    def_delegators "IronBank.configuration", :zuora_users_file
+    def_delegators "IronBank.configuration", :users_file
 
     class << self
       def store
-        return {} unless zuora_users_file
+        return {} unless users_file
 
         @store ||= begin
-          if File.exist?(zuora_users_file)
+          if File.exist?(users_file)
             load_records
           else
-            IronBank.logger.warn "File does not exist: #{zuora_users_file}"
+            IronBank.logger.warn "File does not exist: #{users_file}"
             {}
           end
         end
       end
 
       def load_records
-        CSV.foreach(
-          zuora_users_file,
-          headers: true
-        ).with_object({}) do |row, store|
+        CSV.foreach(users_file, headers: true).with_object({}) do |row, store|
           store[row["User ID"]] = new(row.to_h.compact)
         end
       end

--- a/spec/fixtures/zuora_users.csv
+++ b/spec/fixtures/zuora_users.csv
@@ -1,0 +1,2 @@
+User ID,User Name,First Name,Last Name,Status,Work Email,Created On,Zuora Billing Role,Zuora Payment Role,Zuora Commerce Role,Zuora Platform Role,Zuora Finance Role,Zuora Reporting Role,Zuora Insights Role,Last Login
+zuora-user-id-23456,jane.doe@mail.com,Jane,Doe,Active,jane.doe@mail.com,01/01/2000,Zuora Billing Standard User,Zuora Payments Standard User,Zuora Commerce Admin User,Administrator,N/A,Zuora Reporting Standard User,N/A,12/31/2000

--- a/spec/iron_bank/user_spec.rb
+++ b/spec/iron_bank/user_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+RSpec.describe IronBank::User do
+  before { IronBank.configuration.zuora_users_file = users_file }
+
+  after  do
+    IronBank.configuration.zuora_users_file = nil
+
+    if described_class.instance_variable_defined?(:@store)
+      described_class.remove_instance_variable(:@store)
+    end
+  end
+
+  let(:users_file) { "spec/fixtures/zuora_users.csv" }
+
+  describe ".store" do
+    subject(:store) { described_class.store }
+
+    context "no zuora users file configured" do
+      let(:users_file) { nil }
+      it { is_expected.to eq({}) }
+    end
+
+    context "zuora users file does not exist" do
+      let(:users_file) { "foo.csv" }
+
+      before { allow(IronBank.logger).to receive(:warn) }
+
+      it "warns that the file does not exist" do
+        store
+
+        expect(IronBank.logger).
+          to have_received(:warn).
+          with("File does not exist: foo.csv")
+      end
+
+      it { is_expected.to eq({}) }
+    end
+
+    context "zuora users file exist" do
+      let(:users_file) { "spec/fixtures/zuora_users.csv" }
+
+      it "creates a Hash of Zuora User ID => Zuora User instance" do
+        expect(store).
+          to match("zuora-user-id-23456" => an_instance_of(IronBank::User))
+      end
+    end
+  end
+
+  describe ".all" do
+    let(:users_file) { nil }
+    subject(:all)    { described_class.all }
+    it               { is_expected.to eq([]) }
+  end
+
+  describe ".find" do
+    subject(:find)   { described_class.find(user_id) }
+
+    context "user not found" do
+      let(:user_id) { "not_found" }
+
+      it { is_expected.to be nil }
+    end
+
+    context "user found" do
+      let(:user_id) { "zuora-user-id-23456" }
+
+      it { is_expected.to be_a(IronBank::User) }
+    end
+  end
+
+  describe "an instance" do
+    let(:user_id)  { "zuora-user-id-23456" }
+    let(:instance) { IronBank::User.find(user_id) }
+
+    describe "#id" do
+      subject(:id) { instance.id }
+
+      it "is aliased from #user_id" do
+        expect(id).to eq(instance.user_id)
+      end
+    end
+
+    describe "#inspect" do
+      subject(:inspect) { instance.inspect }
+
+      it "displays the user name" do
+        expect(inspect).to match(/user_name="jane.doe@mail.com"/)
+      end
+    end
+
+    describe "#last_login" do
+      subject(:last_login) { instance.last_login }
+
+      it { is_expected.to be_a(Date) }
+    end
+
+    describe "#created_on" do
+      subject(:created_on) { instance.created_on }
+
+      it { is_expected.to be_a(Date) }
+    end
+
+    describe "instance methods" do
+      let(:methods) do
+        described_class::FIELDS.map do |field|
+          IronBank::Utils.underscore(field.tr(" ", ""))
+        end
+      end
+
+      it "defines a Ruby-friendly method for each fields" do
+        respond_to = methods.map { |method| instance.respond_to?(method) }
+
+        expect(respond_to).to all(be true)
+      end
+    end
+  end
+end

--- a/spec/iron_bank/user_spec.rb
+++ b/spec/iron_bank/user_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe IronBank::User do
   describe ".store" do
     subject(:store) { described_class.store }
 
-    context "no zuora users file configured" do
+    context "when no zuora users file is configured" do
       let(:users_file) { nil }
       it { is_expected.to eq({}) }
     end
 
-    context "zuora users file does not exist" do
+    context "when the configured zuora users file does not exist" do
       let(:users_file) { "foo.csv" }
 
       before { allow(IronBank.logger).to receive(:warn) }
@@ -37,7 +37,7 @@ RSpec.describe IronBank::User do
       it { is_expected.to eq({}) }
     end
 
-    context "zuora users file exist" do
+    context "when the configured zuora users file does exist" do
       let(:users_file) { "spec/fixtures/zuora_users.csv" }
 
       it "creates a Hash of Zuora User ID => Zuora User instance" do
@@ -56,13 +56,16 @@ RSpec.describe IronBank::User do
   describe ".find" do
     subject(:find)   { described_class.find(user_id) }
 
-    context "user not found" do
-      let(:user_id) { "not_found" }
+    context "when a user is not found" do
+      let(:user_id) { "user-id-666" }
 
-      it { is_expected.to be nil }
+      it "raises a NotFoundError" do
+        expect { find }.
+          to raise_error(IronBank::NotFoundError, "user id: #{user_id}")
+      end
     end
 
-    context "user found" do
+    context "when a user is found" do
       let(:user_id) { "zuora-user-id-23456" }
 
       it { is_expected.to be_a(IronBank::User) }

--- a/spec/iron_bank/user_spec.rb
+++ b/spec/iron_bank/user_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe IronBank::User do
-  before { IronBank.configuration.zuora_users_file = users_file }
+  before { IronBank.configuration.users_file = users_file }
 
   after  do
-    IronBank.configuration.zuora_users_file = nil
+    IronBank.configuration.users_file = nil
 
     if described_class.instance_variable_defined?(:@store)
       described_class.remove_instance_variable(:@store)


### PR DESCRIPTION
### Description
Zuora returns `UpdatedById` for most of its resources. This corresponds to the Zuora user ID who last modified that resource. Unfortunately, Zuora does not offer an API for you to query the users in your Zuora tenant.

The [Zuora Knowledge Center](https://knowledgecenter.zuora.com/CF_Users_and_Administrators/A_Administrator_Settings/Manage_Users#Export_User_Data_to_a_CSV_File) does reference a way to export all users in your tenant. We leverage this report through IronBank to let your provide the CSV as a configuration option (`zuora_users_file`).

This make your users available through the `IronBank::User` class.

### API documentation

```rb
IronBank::User.all
# => parse once and returns an array of <#IronBank::User> instances

user = IronBank::User.find(user_id)
# => returns nil if not found, else return the Zuora user associated with this ID

user.user_name
# => returns the user name associated with this user

user.last_login
# => returns the (parsed) `Date` from Zuora (US date format)
```

### Risks
**Low.** Net new feature.
