### PR TITLE
Exclude #price field from RatePlanCharge query

### DIFF
--- a/lib/iron_bank/resources/rate_plan_charge.rb
+++ b/lib/iron_bank/resources/rate_plan_charge.rb
@@ -5,12 +5,14 @@ module IronBank
     # A rate plan charge belongs to a subscription rate plan.
     #
     class RatePlanCharge < Resource
+      extend Gem::Deprecate
+
       def self.excluded_fields
         super + single_resource_query_fields
       end
 
       def self.single_resource_query_fields
-        %w[RolloverBalance]
+        %w[RolloverBalance Price]
       end
 
       with_schema
@@ -25,6 +27,21 @@ module IronBank
       def rollover_balance
         remote[:rollover_balance] || reload.remote[:rollover_balance]
       end
+
+      # NOTE: #price was only available when (1) the pricing model for the
+      #       charge is either "Flat Fee" or "Per Unit" AND (2) the charge was
+      #       queried through ZOQL, i.e, using `IronBank::Charge#where` method.
+      #
+      #       Testing Zuora REST API (using the `IronBank::Charge#find` method)
+      #       shows that Zuora does not return a `price` attribute in their
+      #       response. This means we consider #price to be a remain from the
+      #       SOAP ZOQL query operation. We are deprecating this method without
+      #       replacement. Instead, users should be fetching the `#tiers` for
+      #       the current charge and get the price information from there.
+      def price
+        nil
+      end
+      deprecate :price, :none, 2020, 1
     end
   end
 end

--- a/spec/iron_bank/resources/rate_plan_charge_spec.rb
+++ b/spec/iron_bank/resources/rate_plan_charge_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe IronBank::Resources::RatePlanCharge do
 
   describe "::excluded_fields" do
     subject { described_class.excluded_fields }
-    it { is_expected.to eq(["RolloverBalance"]) }
+    it { is_expected.to eq(%w[RolloverBalance Price]) }
   end
 
   describe "#rollover_balance" do


### PR DESCRIPTION
### Description
`Price` is not a query-able field when the `RatePlanCharge` has a pricing model of:
- Tiered
- Volume
- Discount-Fixed Amount
- Discount Percentage

It was only available for:
- Flat Fee
- Per Unit

And only through the ZOQL query. Zuora does not even add the `:price` attribute in their API response for their [CRUD: Get rate plan charge](https://www.zuora.com/developer/api-reference/#operation/Object_GETRatePlanCharge) operation.

Hence, we are deprecating `IronBank::Charge#price` method and will be removing it in future versions.

### Notes
Users should be using the `#tiers` method for a given `RatePlanCharge` to find out the price information they are looking for.

### Risks
**Low.** Deprecate a method that was not returning the proper response for any pricing model other than "Flat Fee" and "Per Unit."