### PR TITLE
Delegate empty? to records for Collection

### DIFF
--- a/lib/iron_bank/collection.rb
+++ b/lib/iron_bank/collection.rb
@@ -9,6 +9,7 @@ module IronBank
     def_delegators :@records,
                    :[],
                    :each,
+                   :empty?,
                    :length,
                    :map,
                    :size

--- a/spec/iron_bank/collection_spec.rb
+++ b/spec/iron_bank/collection_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe IronBank::Collection do
 
     it { expect delegate_method(:each).to(:records) }
 
+    it { expect delegate_method(:empty?).to(:records) }
+
     it { expect delegate_method(:length).to(:records) }
 
     it { expect delegate_method(:map).to(:records) }


### PR DESCRIPTION
### Description
I found that it would be helpful to use the `.empty?` method on a `Collection`.  I've delegated this method to `@records`, following the pattern of other method delegations in this class.

### Risks
**Low**
