### PR TITLE
Allow max attempts to be configurable parameter to LocalRecords export

### DIFF
--- a/lib/iron_bank/local_records.rb
+++ b/lib/iron_bank/local_records.rb
@@ -25,7 +25,7 @@ module IronBank
     def save_file
       until completed? || max_query?
         IronBank.logger.info(export_query_info)
-        sleep backoff_time
+        sleep BACKOFF[:interval]
       end
 
       File.open(file_path, "w") do |file|
@@ -61,7 +61,7 @@ module IronBank
 
     def export_query_info
       "Waiting for export #{export.id} (#{resource}) to complete " \
-        "(attempt #{query_attempts} of #{@query_max_attempts}; #{backoff_time}s " \
+        "(attempt #{query_attempts} of #{@query_max_attempts}; #{BACKOFF[:interval]}s " \
         "sleeping time)"
     end
 
@@ -84,10 +84,6 @@ module IronBank
       return false unless @query_attempts > @query_max_attempts
 
       raise IronBank::Error, "Export query attempts exceeded"
-    end
-
-    def backoff_time
-      BACKOFF[:interval]
     end
   end
 end

--- a/lib/iron_bank/local_records.rb
+++ b/lib/iron_bank/local_records.rb
@@ -17,7 +17,10 @@ module IronBank
       IronBank.configuration.export_directory
     end
 
-    def self.export(max_attempts = 180)
+    # Example usages
+    # IronBank::LocalRecords.export
+    # IronBank::LocalRecords.export(max_attempts: 260)
+    def self.export(max_attempts: 180)
       FileUtils.mkdir_p(directory) unless Dir.exist?(directory)
       RESOURCE_QUERY_FIELDS.each_key { |resource| new(resource, max_attempts).save_file }
     end
@@ -61,7 +64,7 @@ module IronBank
 
     def export_query_info
       "Waiting for export #{export.id} (#{resource}) to complete " \
-        "(attempt #{query_attempts} of #{@query_max_attempts}; #{BACKOFF[:interval]}s " \
+        "(attempt #{query_attempts} of #{query_max_attempts}; #{BACKOFF[:interval]}s " \
         "sleeping time)"
     end
 
@@ -81,7 +84,7 @@ module IronBank
 
     def max_query?
       @query_attempts += 1
-      return false unless @query_attempts > @query_max_attempts
+      return false unless @query_attempts > query_max_attempts
 
       raise IronBank::Error, "Export query attempts exceeded"
     end

--- a/spec/iron_bank/local_records_spec.rb
+++ b/spec/iron_bank/local_records_spec.rb
@@ -123,10 +123,10 @@ RSpec.describe IronBank::LocalRecords do
             to raise_error(IronBank::Error, "Export query attempts exceeded")
         end
 
-        it "attempts 11 queries" do
+        it "attempts 180 queries" do
           export
         rescue IronBank::Error
-          expect(export_instance).to have_received(:reload).exactly(11).times
+          expect(export_instance).to have_received(:reload).exactly(181).times
         end
       end
 


### PR DESCRIPTION
### Description
Currently the `LocalRecords.export` doesn't always finish within the allotted time. This change makes it so that users can extend the number of attempts (in turn allowing for longer duration) to help the export succeed. 


### Risks
**Low**
