### PR TITLE
Support prefixed variation of "services" hostname.

### DIFF
--- a/lib/iron_bank/endpoint.rb
+++ b/lib/iron_bank/endpoint.rb
@@ -7,7 +7,7 @@ module IronBank
     private_class_method :new
 
     PRODUCTION  = /\Arest\.zuora\.com\z/i.freeze
-    SERVICES    = /\Aservices(\d+)\.zuora\.com(:\d+)?\z/i.freeze
+    SERVICES    = /\A(rest)?services(\d+)\.zuora\.com(:\d+)?\z/i.freeze
     APISANDBOX  = /\Arest.apisandbox.zuora\.com\z/i.freeze
 
     def self.base_url(domain = "")

--- a/spec/iron_bank/endpoint_spec.rb
+++ b/spec/iron_bank/endpoint_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe IronBank::Endpoint do
         let(:hostname) { "services666.zuora.com:12345" }
         it { is_expected.to eq("https://services666.zuora.com:12345/") }
       end
+
+      context "prefixed with 'rest' services hostname" do
+        let(:hostname) { "restservices666.zuora.com:12345" }
+        it { is_expected.to eq("https://restservices666.zuora.com:12345/") }
+      end
     end
 
     context "apisandbox hostname" do


### PR DESCRIPTION
### Description
This change adds support in `IronBank::Endpoint#base_url` to accommodate name variation for the `"services"` subdomain for when it might be prefixed with the word `"rest"` (eg: `"restservices999.zuora.com"`)

### Notes
The new tenant being stood up to replace `services559` is setup to receive request at `restservices058`

### Risks
**Low.** Updates validation in `IronBank::Endpoint#base_url` to allow for the `"rest"` prefix (eg: `restservices123` vs `services123`)
