### PR TITLE
Allow LocalRecord `where` to accept array of values

### DIFF
--- a/lib/iron_bank/local.rb
+++ b/lib/iron_bank/local.rb
@@ -25,7 +25,9 @@ module IronBank
 
     def where(conditions, limit: IronBank::Actions::Query::DEFAULT_ZUORA_LIMIT)
       records = store.values.select do |record|
-        conditions.all? { |field, value| record.public_send(field) == value }
+        conditions.all? do |field, match_value|
+          value_matches?(record.public_send(field), match_value)
+        end
       end
 
       records.any? ? records : super
@@ -80,6 +82,15 @@ module IronBank
         "#{object_name}.csv",
         IronBank.configuration.export_directory
       )
+    end
+
+    # :reek:UtilityFunction
+    def value_matches?(record_value, match_value)
+      if match_value.is_a? Array
+        match_value.include? record_value
+      else
+        record_value == match_value
+      end
     end
   end
 end

--- a/spec/iron_bank/local_spec.rb
+++ b/spec/iron_bank/local_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe IronBank::Local do
+  describe "::where" do
+    subject do
+      TestLocaleModuleResource = Struct.new(:id, :name, :type) do
+        extend IronBank::Local
+      end
+    end
+
+    let(:resource1) { subject.new("id1", "n1", "Foo") }
+    let(:resource2) { subject.new("id2", "n1", "Foo") }
+    let(:resource3) { subject.new("id3", "n1", "Bar") }
+
+    before do
+      allow(subject).to receive(:store).and_return(
+        {
+          "id1" => resource1,
+          "id2" => resource2,
+          "id3" => resource3
+        }
+      )
+    end
+
+    context "when condition is single value" do
+      it "returns matches against value" do
+        expect(subject.where(id: "id1")).to contain_exactly(resource1)
+        expect(subject.where(type: "Foo")).to contain_exactly(resource1, resource2)
+      end
+    end
+
+    context "when condition is an array of values" do
+      it "returns matches against any element of the array" do
+        expect(subject.where(id: %w[id1 id3])).to contain_exactly(resource1, resource3)
+        expect(subject.where(type: %w[Foo Bar])).to contain_exactly(resource1, resource2, resource3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

The `Queryable` module allows querying multiple ids in one query,
however `LocalRecord` module does not,
so if I query with multiple IDs, cached local records will be ignored.

This PR bring feature parity to local records.

### Notes
Extra information (technical references, etc.) that you would like the reviewers
to be aware of.


### Risks
Medium