### PR TITLE
fix: excluded fields

### DIFF
--- a/lib/iron_bank/describe/excluded_fields.rb
+++ b/lib/iron_bank/describe/excluded_fields.rb
@@ -87,7 +87,7 @@ module IronBank
         info "Successful query for #{object_name}"
 
         true
-      rescue IronBank::InternalServerError => e
+      rescue IronBank::InternalServerError, IronBank::BadRequestError => e
         @last_failed_fields = extract_fields_from_exception(e)
 
         false


### PR DESCRIPTION
Fixes #63 

### Description

This list is generated by querying Zuora with all fields, and removing
the faulty fields, one by one, until the query succeeds.

Until recently, Zuora was returning HTTP 500 Internal Server Error when
a non-queryable field was passed in the query. It now returns HTTP 400
Bad Request Error, but this exception was not rescued in the service
class generating the list of excluded fields.

### Risks

**Low** since it's broken with the current Zuora release.
