### PR TITLE
Update regex for staging zuora

### DIFF
--- a/lib/iron_bank/endpoint.rb
+++ b/lib/iron_bank/endpoint.rb
@@ -7,7 +7,7 @@ module IronBank
     private_class_method :new
 
     PRODUCTION  = /\Arest\.zuora\.com\z/i.freeze
-    SERVICES    = /\A(rest)?services(\d+)\.zuora\.com(:\d+)?\z/i.freeze
+    SERVICES    = /\A(rest)?(\.)?[a-z]+(\d+)?\.zuora\.com(:\d+)?\z/i.freeze
     APISANDBOX  = /\Arest.apisandbox.zuora\.com\z/i.freeze
 
     def self.base_url(domain = "")

--- a/spec/iron_bank/endpoint_spec.rb
+++ b/spec/iron_bank/endpoint_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe IronBank::Endpoint do
         it { is_expected.to eq("https://services666.zuora.com/") }
       end
 
+      context "no digits services hostname" do
+        let(:hostname) { "services.zuora.com" }
+        it { is_expected.to eq("https://services.zuora.com/") }
+      end
+
       context "uppercase services hostname" do
         let(:hostname) { "SERVICES123.ZUORA.COM" }
         it { is_expected.to eq("https://services123.zuora.com/") }
@@ -53,6 +58,11 @@ RSpec.describe IronBank::Endpoint do
       context "prefixed with 'rest' services hostname" do
         let(:hostname) { "restservices666.zuora.com:12345" }
         it { is_expected.to eq("https://restservices666.zuora.com:12345/") }
+      end
+
+      context "prefixed with 'rest.' services hostname" do
+        let(:hostname) { "rest.test.zuora.com:12345" }
+        it { is_expected.to eq("https://rest.test.zuora.com:12345/") }
       end
     end
 


### PR DESCRIPTION
### Description
Update the regex to reflect the new zuora instance url in staging `rest.test.zuora.com`.

Jira: https://zendesk.atlassian.net/browse/WALR-5898

### Risks
**Medium**: It may break connection to staging.