### PR TITLE
Add support to query custom fields for resource objects

### DIFF
--- a/lib/iron_bank/describe/object.rb
+++ b/lib/iron_bank/describe/object.rb
@@ -56,6 +56,16 @@ module IronBank
         @query_fields ||= fields.select(&:selectable?).map(&:name)
       end
 
+      def query_custom_fields
+        @query_custom_fields ||= begin
+          custom_fields = fields.select do |field|
+            field.selectable? && field.custom?
+          end
+
+          custom_fields.map(&:name)
+        end
+      end
+
       def related
         @related ||= doc.xpath(".//related-objects/object").map do |node|
           IronBank::Describe::Related.from_xml(node)

--- a/lib/iron_bank/metadata.rb
+++ b/lib/iron_bank/metadata.rb
@@ -31,6 +31,12 @@ module IronBank
       @query_fields ||= schema.query_fields - excluded_fields
     end
 
+    def query_custom_fields
+      return [] unless schema
+
+      @query_custom_fields ||= schema.query_custom_fields - excluded_fields
+    end
+
     def schema
       @schema ||= IronBank::Schema.for(object_name)
     end

--- a/spec/fixtures/objects/account.xml
+++ b/spec/fixtures/objects/account.xml
@@ -26,7 +26,7 @@
          <createable>true</createable>
          <updateable>true</updateable>
          <filterable>true</filterable>
-         <custom>false</custom>
+         <custom>true</custom>
          <maxlength/>
          <required>false</required>
          <type>text</type>
@@ -46,6 +46,22 @@
          <maxlength/>
          <required>false</required>
          <type>boolean</type>
+         <contexts>
+            <context>soap</context>
+            <context>export</context>
+         </contexts>
+      </field>
+      <field>
+         <name>MyCustomField__c</name>
+         <label>MyCustomField__c</label>
+         <selectable>true</selectable>
+         <createable>true</createable>
+         <updateable>true</updateable>
+         <filterable>true</filterable>
+         <custom>true</custom>
+         <maxlength/>
+         <required>true</required>
+         <type>text</type>
          <contexts>
             <context>soap</context>
             <context>export</context>

--- a/spec/iron_bank/describe/object_spec.rb
+++ b/spec/iron_bank/describe/object_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe IronBank::Describe::Object do
             AccountNumber
             AdditionalEmailAddresses
             AllowInvoiceEdit
+            MyCustomField__c
             Name
           ]
         end
@@ -34,8 +35,15 @@ RSpec.describe IronBank::Describe::Object do
       end
 
       describe "#query_fields" do
-        let(:fields) { %w[AccountNumber Name] }
+        let(:fields) { %w[AccountNumber MyCustomField__c Name] }
         subject { object.query_fields }
+        it { is_expected.to eq(fields) }
+      end
+
+      describe "#query_custom_fields" do
+        let(:fields) { %w[MyCustomField__c] }
+        subject { object.query_custom_fields }
+
         it { is_expected.to eq(fields) }
       end
 

--- a/spec/shared_examples/metadata.rb
+++ b/spec/shared_examples/metadata.rb
@@ -72,6 +72,33 @@ RSpec.shared_examples "a resource with metadata" do
     end
   end
 
+  describe "#query_custom_fields" do
+    subject { described_class.query_custom_fields }
+
+    context "without a schema" do
+      it { is_expected.to eq([]) }
+    end
+
+    context "with a schema" do
+      let(:query_custom_fields) { %w[MyCustomField__c ExcludedField] }
+
+      before do
+        allow(IronBank::Schema).to receive(:for).and_return(schema)
+        allow(schema).to receive(:query_custom_fields).and_return(query_custom_fields)
+        allow(described_class).to receive(:excluded_fields).and_return(excluded)
+      end
+
+      after do
+        # NOTE: Not resetting the instance variable here seems to leak the
+        #       `instance_double(IronBank::Describe::Object)` to the other
+        #       examples.
+        described_class.remove_instance_variable :@schema
+      end
+
+      it { is_expected.to eq(%w[MyCustomField__c]) }
+    end
+  end
+
   describe "#with_schema" do
     let(:fields)  { %w[AccountNumber MyCustomField__c] }
     let(:methods) { %i[account_number my_custom_field__c] }


### PR DESCRIPTION
### Description

* Add support to query custom fields for resources
* returns an array of all selectable custom fields

Usage: 

```
IronBank::Account.query_custom_fields 
[ "MyCustomField__c_1", "MyCustomField__c_2" ... ]
```

### Risks
**Medium** 

* adds support to query selectable custom fields, shouldn't break any existing features
