### PR TITLE
[OTTR-1206] Default IronBank to use the Zuora minor version 211.0

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -19,6 +19,7 @@ detectors:
       - IronBank::Configuration#middlewares
       - IronBank::Configuration#schema_directory
       - IronBank::Configuration#users_file
+      - IronBank::Configuration#api_minor_version
 
   BooleanParameter:
     exclude:

--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -101,9 +101,9 @@ module IronBank
     def headers
       config = IronBank.Configuration
       header = auth.header.reverse_merge(
+        "Content-Type" => "application/json",
         "zuora-version" => config.api_minor_version
       )
-      { "Content-Type" => "application/json" }.merge(header)
     end
 
     def reset_connection

--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -99,7 +99,7 @@ module IronBank
     end
 
     def headers
-      config = IronBank.Configuration
+      config = IronBank.configuration
       auth.header.reverse_merge(
         "Content-Type"  => "application/json",
         "zuora-version" => config.api_minor_version

--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -101,7 +101,7 @@ module IronBank
     def headers
       config = IronBank.Configuration
       auth.header.reverse_merge(
-        "Content-Type" => "application/json",
+        "Content-Type"  => "application/json",
         "zuora-version" => config.api_minor_version
       )
     end

--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -100,7 +100,7 @@ module IronBank
 
     def headers
       config = IronBank.Configuration
-      header = auth.header.reverse_merge(
+      auth.header.reverse_merge(
         "Content-Type" => "application/json",
         "zuora-version" => config.api_minor_version
       )

--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -100,6 +100,10 @@ module IronBank
 
     def headers
       { "Content-Type" => "application/json" }.merge(auth.header)
+      config = IronBank.Configuration
+      auth.header.reverse_merge(
+        "zuora-version" => config.api_minor_version
+      )
     end
 
     def reset_connection

--- a/lib/iron_bank/client.rb
+++ b/lib/iron_bank/client.rb
@@ -99,11 +99,11 @@ module IronBank
     end
 
     def headers
-      { "Content-Type" => "application/json" }.merge(auth.header)
       config = IronBank.Configuration
-      auth.header.reverse_merge(
+      header = auth.header.reverse_merge(
         "zuora-version" => config.api_minor_version
       )
+      { "Content-Type" => "application/json" }.merge(header)
     end
 
     def reset_connection

--- a/lib/iron_bank/configuration.rb
+++ b/lib/iron_bank/configuration.rb
@@ -37,12 +37,16 @@ module IronBank
     # File path for Zuora users export
     attr_accessor :users_file
 
+    # Specify a minor version
+    attr_accessor :api_minor_version
+
     def initialize
-      @schema_directory = "./config/schema"
-      @export_directory = "./config/export"
-      @logger           = IronBank::Logger.new
-      @auth_type        = "token"
-      @middlewares      = []
+      @schema_directory   = "./config/schema"
+      @export_directory   = "./config/export"
+      @logger             = IronBank::Logger.new
+      @auth_type          = "token"
+      @middlewares        = []
+      @api_minor_version  = "0.0"
     end
 
     def schema_directory=(value)

--- a/lib/iron_bank/configuration.rb
+++ b/lib/iron_bank/configuration.rb
@@ -46,7 +46,7 @@ module IronBank
       @logger             = IronBank::Logger.new
       @auth_type          = "token"
       @middlewares        = []
-      @api_minor_version  = "0.0"
+      @api_minor_version  = "211.0"
     end
 
     def schema_directory=(value)


### PR DESCRIPTION
### Description
Default Iron Bank to use Zuora at version 211.0 This PR is being blocked by [Update Env](https://github.com/zendesk/iron_bank/pull/86)

### References

- JIRA ticket: [OTTR-1206](https://zendesk.atlassian.net/browse/OTTR-1206)

### Risks
Medium - Configuration on Iron Bank might effect all clients.