### PR TITLE
IronBank::Collection has learned #to_ary in order to support implicit array conversions

### DIFF
--- a/lib/iron_bank/collection.rb
+++ b/lib/iron_bank/collection.rb
@@ -12,7 +12,8 @@ module IronBank
                    :empty?,
                    :length,
                    :map,
-                   :size
+                   :size,
+                   :to_ary
 
     def initialize(klass, conditions, records)
       @klass = klass

--- a/spec/iron_bank/collection_spec.rb
+++ b/spec/iron_bank/collection_spec.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe IronBank::Collection do
-  let(:klass) { IronBank::Resource }
-  let(:records) { [] }
+  let(:klass) do
+    Class.new(IronBank::Resource) do
+      def related_records
+        remote[:related_records]
+      end
+    end
+  end
+  let(:records) { build_resources }
   let(:conditions) { { account_id: "123" } }
   let(:subject) { described_class.new(klass, conditions, records) }
 
+  def build_resources(*resource_attributes)
+    resource_attributes.map { |attributes| klass.new(attributes) }
+  end
+
   describe "#reload" do
-    let(:new_records) { [{ id: "xyz", name: "Foo Loo" }] }
+    let(:new_records) { build_resources({ id: "xyz", name: "Foo Loo" }) }
     let(:reload) { subject.reload }
 
     it "makes a live where query" do
@@ -26,6 +36,52 @@ RSpec.describe IronBank::Collection do
 
   describe "#to_a" do
     it { expect(subject.to_a).to eq(records) }
+  end
+
+  describe "implicit conversions" do
+    let(:records) do
+      build_resources(
+        { id: "1", related_records: described_class.new(klass, conditions, build_resources(*fruits)) },
+        { id: "2", related_records: described_class.new(klass, conditions, build_resources(*vegetables)) },
+        { id: "3", related_records: described_class.new(klass, conditions, build_resources(*nonedibles)) }
+      )
+    end
+
+    let(:fruits) { [{ id: "1", name: "Apples" }, { id: "2", name: "Bananas" }] }
+    let(:vegetables) { [{ id: "3", name: "Carrots" }, { id: "7", name: "Onions" }] }
+    let(:nonedibles) { [{ id: "5", name: "Rocks" }, { id: "6", name: "Bark" }] }
+
+    it "supports implicit conversion to an array" do
+      first, second, third = subject
+
+      expect(first).to eq records[0]
+      expect(second).to eq records[1]
+      expect(third).to eq records[2]
+    end
+
+    it "works with methods that rely on implicit array conversion under the hood such as #flat_map" do
+      expected_records = build_resources(*[fruits, vegetables, nonedibles].flatten)
+      expect(records.flat_map(&:related_records)).to eq expected_records
+    end
+  end
+
+  describe "#flat_map" do
+    let(:records) do
+      build_resources(
+        { id: "1", related_records: described_class.new(klass, conditions, build_resources(*fruits)) },
+        { id: "2", related_records: described_class.new(klass, conditions, build_resources(*vegetables)) },
+        { id: "3", related_records: described_class.new(klass, conditions, build_resources(*nonedibles)) }
+      )
+    end
+
+    let(:fruits) { [{ id: "1", name: "Apples" }, { id: "2", name: "Bananas" }] }
+    let(:vegetables) { [{ id: "3", name: "Carrots" }, { id: "7", name: "Onions" }] }
+    let(:nonedibles) { [{ id: "5", name: "Rocks" }, { id: "6", name: "Bark" }] }
+
+    it "works correctly" do
+      expected_records = build_resources(*[fruits, vegetables, nonedibles].flatten)
+      expect(records.flat_map(&:related_records)).to eq expected_records
+    end
   end
 
   describe "delegates object methods to records" do


### PR DESCRIPTION
## Description

This change-set implements `IronBank::Collection#to_ary` as a way to support implicit array conversions in Ruby. 

IronBank::Collection is not an array, but it tries to mimic acting like one. In some instances, this results in it not quite working where one would expect.

### Change details

This  allows things like the below to work:

```ruby
# Pull out the first three records from the IronBank::Collection instance. Without this change
# this doesn't work as expected.
a, b, c = some_iron_bank_collection

# Any method that relied on implicit conversion now works as expected.
# Without this change this doesn't work as expected.
account = IronBank::Account.find(...)
rate_plans = account.subscriptions.flat_map(&:rate_plans)
```

Prior to this change anything that relied on impilcit conversion returned an IronBank::Collection which led to some strange results. 

### Vetting locally

#### Vetting implicit conversion via assignment

Running the below code for an account  with multiple subscriptions:

```ruby
account = IronBank::Account.find(...)
s1, s2 = account.subscriptions
```

Before this change-set `s1` was assigned to the whole collection and `s2` was `nil`:

<img width="777" alt="before-assignment" src="https://user-images.githubusercontent.com/967/175093053-85397d57-51a3-45f3-958f-d84440d46ca1.png">

After this change-sett this assigned the `s1` and `s2` to the first and second elements of the collection:

<img width="745" alt="after-assignment" src="https://user-images.githubusercontent.com/967/175093131-a16e61f1-28ec-4aee-bab9-837cf5ab5231.png">

#### Testing out flat_map

Locally, I loaded up an account and tried to `flat_map` on the subscriptions' rate_plans. Running:

```shell
account = IronBank::Account.find(...)
account.subscriptions.flat_map(&:rate_plans)
```

Before this change-set this resulted in an array of rate plan collections rather than a flattened list of rate plans. This was unexpected as this is not how flat_map is expected to work:

<img width="889" alt="before-flat-map" src="https://user-images.githubusercontent.com/967/175091767-16a3c232-9da0-4b9d-b026-8d720722f499.png">

After this change-set the `flat_map` results in an array of the rate plans. This is what I would have expected given how `flat_map` works:

<img width="792" alt="after-flat_map" src="https://user-images.githubusercontent.com/967/175091793-da6ed683-94ec-4f32-a103-ee5854bfd0e0.png">



### Tasks
- [x] Post screenshot / screencast 

### Risks

**Low** this could break code if it relies on the behavior without implicit array conversion, but that is less than likely given that that functionality comes across as broken in use

