### PR TITLE
[BILL-16296] Bump nokogiri to 1.13.10 due to CVE-2022-23476

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.14.3)
     multipart-post (2.2.3)
-    nokogiri (1.13.9)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)


### PR DESCRIPTION
### Description
This [snyk security vulnerability](https://app.snyk.io/org/growth-and-monetization/project/32542bd6-870c-495b-b68d-82c1f8f4d697/pr-check/4213318d-5b46-46ff-86e0-99797d4bea0d) for [CVE-2022-23476](https://www.cve.org/CVERecord?id=CVE-2022-23476) indicates we need to bump nokogiri to 1.13.10. 

From Snyk: 

> [nokogiri](https://nokogiri.org/) is a gem for parsing HTML, XML, SAX, and Reader.
>
> Affected versions of this package are vulnerable to Unchecked Return Value due to failing to check the return value from xmlTextReaderExpand in the method Nokogiri::XML::Reader#attribute_hash. Exploiting this vulnerability can lead to a null pointer exception when parsing invalid markup.

### Links
- [BILL-16296](https://zendesk.atlassian.net/browse/BILL-16296)

### Risks
**Medium** bumps nokogiri gem
