### PR TITLE
Adding basic workflow to publish released gems

### DIFF
--- a/.github/workflows/ruby-gem-publication
+++ b/.github/workflows/ruby-gem-publication
@@ -1,0 +1,12 @@
+name: Ruby Gem Publish
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}


### PR DESCRIPTION
### Description
This adds a new workflow to publish new versions of the IronBank gem to RubyGems.org without needing permissions to do so manually.

### Notes
Reference - https://github.com/zendesk/gw/blob/d01a1fa90248f834bc73ed8244895746654c88e1/ruby-gem-publication/README.md

### Tasks
- [x] What needs to be done in order to publish the current version of IronBank, v5.3.1?

### Risks
**Medium** changes to GH CI to publish new gems.