### PR TITLE
Update faraday to 2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     iron_bank (5.4.1)
-      faraday (~> 1)
-      faraday_middleware (~> 1)
+      faraday (~> 2)
+      faraday-retry (~> 2)
       nokogiri (~> 1)
 
 GEM
@@ -34,40 +34,25 @@ GEM
       ruby2_keywords
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
     i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     kwalify (0.7.2)
+    logger (1.6.6)
     method_source (1.0.0)
     mini_portile2 (2.8.2)
     minitest (5.18.0)
-    multipart-post (2.3.0)
     mutex_m (0.2.0)
+    net-http (0.6.0)
+      uri
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -131,6 +116,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    uri (1.0.3)
 
 PLATFORMS
   ruby

--- a/iron_bank.gemspec
+++ b/iron_bank.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday",            "~> 1"
-  spec.add_dependency "faraday_middleware", "~> 1"
+  spec.add_dependency "faraday",            "~> 2"
+  spec.add_dependency "faraday-retry",      "~> 2"
   spec.add_dependency "nokogiri",           "~> 1"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/lib/iron_bank.rb
+++ b/lib/iron_bank.rb
@@ -3,10 +3,10 @@
 # External librairies
 require "csv"
 require "faraday"
-require "faraday_middleware"
 require "fileutils"
 require "json"
 require "nokogiri"
+require "faraday/retry"
 
 # An opinionated Ruby interface to the Zuora REST API
 module IronBank

--- a/lib/iron_bank/faraday_middleware/response/raise_error.rb
+++ b/lib/iron_bank/faraday_middleware/response/raise_error.rb
@@ -8,7 +8,7 @@ module IronBank
     module Response
       # This class raises an exception based on the HTTP status code and the
       # `success` flag (if present in the response) from Zuora.
-      class RaiseError < Faraday::Response::Middleware
+      class RaiseError < Faraday::Middleware
         def on_complete(env)
           (error = IronBank::Error.from_response(env.response)) && raise(error)
         end

--- a/lib/iron_bank/faraday_middleware/response/renew_auth.rb
+++ b/lib/iron_bank/faraday_middleware/response/renew_auth.rb
@@ -7,7 +7,7 @@ module IronBank
     # IronBank Faraday response middleware module
     module Response
       # This middleware reauthorize the request on unauthorized request
-      class RenewAuth < Faraday::Response::Middleware
+      class RenewAuth < Faraday::Middleware
         def initialize(app, auth)
           @auth = auth
 


### PR DESCRIPTION
### Description
Updates faraday to 2.x

Gem diff: https://github.com/lostisland/faraday/compare/v1.10.3...v2.12.0

### Notes


### Tasks
- [ ] TODO item before it can be reviewed and/or merged
- [ ] Another TODO item

### Risks
Medium: Major version bump to faraday which contains breaking changes
