### PR TITLE
OCTO-68, Zuora Order API Adoption

### DIFF
--- a/lib/iron_bank.rb
+++ b/lib/iron_bank.rb
@@ -75,6 +75,7 @@ require "iron_bank/actions/subscribe"
 require "iron_bank/actions/update"
 require "iron_bank/actions/query"
 require "iron_bank/actions/query_more"
+require "iron_bank/actions/order"
 
 # Client and schema (describe)
 require "iron_bank/authentication"

--- a/lib/iron_bank/actions/order.rb
+++ b/lib/iron_bank/actions/order.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module IronBank
+  module Actions
+    # Use the order operation to create subscriptions and make changes to subscriptions by creating orders
+    # https://developer.zuora.com/v1-api-reference/api/operation/POST_Order/
+    #
+    class Order < Action
+      private
+
+      def endpoint
+        "v1/orders"
+      end
+
+      def params
+        base_order.tap do |order|
+          optional_keys.each do |key, method|
+            order[key] = send(method) if args.key?(key)
+          end
+        end
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def optional_keys
+        {
+          category:              :fetch_category,
+          newAccount:            :fetch_new_account,
+          existingAccountNumber: :fetch_existing_account_number,
+          customFields:          :fetch_custom_fields,
+          reasonCode:            :fetch_reason_code,
+          status:                :fetch_status,
+          orderLineItems:        :fetch_order_line_items,
+          processingOptions:     :fetch_processing_options,
+          schedulingOptions:     :fetch_scheduling_options
+        }
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def fetch_category
+        args[:category]
+      end
+
+      def fetch_new_account
+        IronBank::Object.new(args.fetch(:newAccount)).deep_camelize(type: :lower)
+      end
+
+      def fetch_existing_account_number
+        args[:existingAccountNumber]
+      end
+
+      def fetch_custom_fields
+        IronBank::Object.new(args.fetch(:customFields)).deep_camelize(type: :upper)
+      end
+
+      def fetch_reason_code
+        args[:reasonCode]
+      end
+
+      def fetch_status
+        args[:status]
+      end
+
+      def fetch_order_line_items
+        IronBank::Object.new(args.fetch(:orderLineItems)).deep_camelize(type: :lower)
+      end
+
+      def fetch_processing_options
+        IronBank::Object.new(args.fetch(:processingOptions)).deep_camelize(type: :lower)
+      end
+
+      def fetch_scheduling_options
+        IronBank::Object.new(args.fetch(:schedulingOptions)).deep_camelize(type: :lower)
+      end
+
+      def subscriptions
+        IronBank::Object.new(args.fetch(:subscriptions)).deep_camelize(type: :lower)
+      end
+
+      def base_order
+        {
+          orderDate:     args.fetch(:orderDate),
+          subscriptions: subscriptions
+        }
+      end
+    end
+  end
+end

--- a/spec/iron_bank/actions/order_spec.rb
+++ b/spec/iron_bank/actions/order_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "shared_examples/action"
+
+RSpec.describe IronBank::Actions::Order do
+  it_behaves_like "a Zuora action" do
+    let(:args) do
+      {
+        orderDate:             "2020-01-01",
+        existingAccountNumber: "A00000001",
+        subscriptions:         []
+      }
+    end
+
+    let(:endpoint) { "v1/orders" }
+
+    let(:params) do
+      {
+        orderDate:             "2020-01-01",
+        existingAccountNumber: "A00000001",
+        subscriptions:         []
+      }
+    end
+
+    let(:body) do
+      {
+        "success"             => true,
+        "orderNumber"         => "O-00179454",
+        "accountNumber"       => "ZUORA00067933",
+        "status"              => "Completed",
+        "subscriptionNumbers" => ["ZD-S00070192"]
+      }
+    end
+  end
+end


### PR DESCRIPTION
### Description
This pull request adds support for the Zuora Orders API feature, enabling our application to integrate with Zuora's new [Order feature](https://developer.zuora.com/v1-api-reference/api/operation/POST_Order/). Key changes include the implementation of necessary API endpoints, updates to data models, and validation enhancements to ensure proper order processing. This integration will improve synchronization with Zuora's order management system and lay the groundwork for future enhancements.


Can be used this way

```ruby
IronBank::Order.call(
 {
     :orderDate=>"2025-03-26", 
     :existingAccountNumber=>"ZUORA000000", 
     :subscriptions=>[]
  }
)
```

### Notes

1. Jira: https://zendesk.atlassian.net/browse/OCTO-68
2. https://knowledgecenter.zuora.com/Zuora_Billing/Manage_accounts%2C_subscriptions%2C_and_non-subscription_transactions/Manage_subscription_transactions/Orders_Harmonization/A_Overview_of_Orders_Harmonization

### Tasks
- [ ] TODO item before it can be reviewed and/or merged
- [ ] Another TODO item

### Risks
Low: New feature for supporting zuora order API