### PR TITLE
Update faraday and uri gems for CVE fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       ruby2_keywords
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
-    faraday (2.12.2)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    uri (1.0.3)
+    uri (1.1.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Summary
- Update faraday 2.12.2 → 2.14.1 (resolves CVE-2026-25765 — SSRF via protocol-relative URL host override)
- Update uri 1.0.3 → 1.1.1 (resolves CVE-2025-61594 — credential leakage bypass)

## Commits
| Gem | Change | CVE |
|-----|--------|-----|
| faraday | 2.12.2 → 2.14.1 | CVE-2026-25765 |
| uri | 1.0.3 → 1.1.1 | CVE-2025-61594 |

## Test plan
- [x] `bundle check` passes
- [x] `bundle exec rspec` — 458 examples, 0 failures
- [ ] CI passes
- [ ] Dependabot alerts auto-dismiss after merge
