### PR TITLE
Bump version to 6.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iron_bank (6.0.0)
+    iron_bank (6.1.1)
       csv (~> 3)
       faraday (~> 2)
       faraday-retry (~> 2)

--- a/lib/iron_bank/version.rb
+++ b/lib/iron_bank/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IronBank
-  VERSION     = "6.0.0"
+  VERSION     = "6.1.1"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
## Summary
- Bumps iron_bank gem version from 6.0.0 to 6.1.1
- Updates Gemfile.lock accordingly
- Once merged to main, the `publish.yml` workflow will auto-trigger (detects version.rb change) and publish to RubyGems + create the v6.1.1 tag

## Risks
Low