### PR TITLE
Security updates: rexml, activesupport + bump to 6.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in zuora.gemspec
 gemspec
 
+gem "activesupport",       "~> 7.2"
 gem "bump",                "~> 0.5"
 gem "bundler",             "~> 2.0"
 gem "dotenv",              "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,30 +10,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.1)
+    activesupport (7.2.3.1)
       base64
+      benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     ast (2.4.2)
-    base64 (0.2.0)
-    bigdecimal (3.1.4)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
     bump (0.10.0)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     csv (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dotenv (2.8.1)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.3)
     factory_bot (6.6.0)
       activesupport (>= 6.1.0)
     faraday (2.14.1)
@@ -44,15 +46,14 @@ GEM
       net-http (>= 0.5.0)
     faraday-retry (2.2.0)
       faraday (~> 2.0)
-    i18n (1.13.0)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     kwalify (0.7.2)
     logger (1.6.6)
     method_source (1.0.0)
     mini_portile2 (2.8.2)
-    minitest (5.18.0)
-    mutex_m (0.2.0)
+    minitest (5.27.0)
     net-http (0.6.0)
       uri
     nokogiri (1.19.3)
@@ -105,7 +106,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     simplecov (0.22.0)
@@ -124,6 +125,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 7.2)
   bump (~> 0.5)
   bundler (~> 2.0)
   dotenv (~> 2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       parser (~> 3.2.0)
       rainbow (>= 2.0, < 4.0)
     regexp_parser (2.8.0)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iron_bank (6.1.1)
+    iron_bank (6.2.0)
       csv (~> 3)
       faraday (~> 2)
       faraday-retry (~> 2)

--- a/lib/iron_bank/version.rb
+++ b/lib/iron_bank/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IronBank
-  VERSION     = "6.1.1"
+  VERSION     = "6.2.0"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
## Summary

- Update rexml 3.4.1 → 3.4.4 (CVE-2025-58767)
- Update activesupport 7.1.1 → 7.2.3.1 (CVE-2026-33176, CVE-2026-33169, CVE-2026-33170)
- Bump version to 6.2.0 for release

## Security Updates

| # | Commit | Command | Gems Updated |
|---|--------|---------|--------------|
| 1 | `46efe74` | `bundle update rexml --conservative` | rexml 3.4.1 → 3.4.4 |
| 2 | `63930ac` | `bundle update activesupport --conservative` | activesupport 7.1.1 → 7.2.3.1 |
| 3 | `d589358` | version bump | 6.1.1 → 6.2.0 |

## Dependabot Coverage

4/4 open RubyGems alerts resolved by this PR.

| Alert | Gem | Severity | CVE | Status |
|-------|-----|----------|-----|--------|
| — | rexml | low | CVE-2025-58767 | ✅ Resolved (3.4.4) |
| — | activesupport | medium | CVE-2026-33176 | ✅ Resolved (7.2.3.1) |
| — | activesupport | medium | CVE-2026-33169 | ✅ Resolved (7.2.3.1) |
| — | activesupport | medium | CVE-2026-33170 | ✅ Resolved (7.2.3.1) |

## Impact on Consumers

- `activesupport` and `rexml` are **dev-only dependencies** — not in the gemspec runtime deps
- Version 6.2.0 is compatible with all repos using `~> 6.0`
- **billing** and **test-governance** pin `~> 6.0.0` — they'll need constraint updates to pick up 6.2.0

## Test plan

- [x] `bundle check` passes
- [x] `bundle exec rspec` — 458 examples, 0 failures
- [ ] CI passes on this branch
- [ ] Create GitHub release v6.2.0 after merge

References: https://zendesk.atlassian.net/browse/AIKYA-607
