### PR TITLE
chore: update ownership to Aikya

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zendesk/billing
+* @zendesk/aikya


### PR DESCRIPTION
### Description

Updated ownership of codewoerners to Aikya (to match [Cerebro](https://cerebro.zende.sk/repositories/iron_bank)).

### Risks
**None**: Updated codeowners only
